### PR TITLE
*: Introduce OwnerReference to RunnerGroup

### DIFF
--- a/api/types/runner_group.go
+++ b/api/types/runner_group.go
@@ -19,4 +19,8 @@ type RunnerGroupSpec struct {
 	NodeAffinity map[string][]string `json:"nodeAffinity,omitempty" yaml:"nodeAffinity"`
 	// ServiceAccount is the name of the ServiceAccount to use to run runners.
 	ServiceAccount *string `json:"serviceAccount,omitempty" yaml:"serviceAccount"`
+	// OwnerReference is to mark the runner group depending on this object.
+	//
+	// FORMAT: APIVersion:Kind:Name:UID
+	OwnerReference *string `json:"ownerReference,omitempty" yaml:"ownerReference"`
 }


### PR DESCRIPTION
It's used to cleanup completed runner group.

Part of #33 
Follow-up of #41 