### PR TITLE
*: use float64 for rate

### DIFF
--- a/api/types/load_traffic.go
+++ b/api/types/load_traffic.go
@@ -15,7 +15,7 @@ type LoadProfile struct {
 // LoadProfileSpec defines the load traffic for traget resource.
 type LoadProfileSpec struct {
 	// Rate defines the maximum requests per second (zero is no limit).
-	Rate int `json:"rate" yaml:"rate"`
+	Rate float64 `json:"rate" yaml:"rate"`
 	// Total defines the total number of requests.
 	Total int `json:"total" yaml:"total"`
 	// Conns defines total number of long connections used for traffic.

--- a/api/types/load_traffic_test.go
+++ b/api/types/load_traffic_test.go
@@ -62,7 +62,7 @@ spec:
 	require.NoError(t, yaml.Unmarshal([]byte(in), &target))
 	assert.Equal(t, 1, target.Version)
 	assert.Equal(t, "test", target.Description)
-	assert.Equal(t, 100, target.Spec.Rate)
+	assert.Equal(t, float64(100), target.Spec.Rate)
 	assert.Equal(t, 10000, target.Spec.Total)
 	assert.Equal(t, 2, target.Spec.Conns)
 	assert.Len(t, target.Spec.Requests, 5)

--- a/cmd/kperf/commands/runner/runner.go
+++ b/cmd/kperf/commands/runner/runner.go
@@ -53,7 +53,7 @@ var runCommand = cli.Command{
 			Usage: "Content type (json or protobuf)",
 			Value: "json",
 		},
-		cli.IntFlag{
+		cli.Float64Flag{
 			Name:  "rate",
 			Usage: "Maximum requests per second (Zero means no limitation). It can override corresponding value defined by --config",
 		},
@@ -145,7 +145,7 @@ func loadConfig(cliCtx *cli.Context) (*types.LoadProfile, error) {
 
 	// override value by flags
 	if v := "rate"; cliCtx.IsSet(v) {
-		profileCfg.Spec.Rate = cliCtx.Int(v)
+		profileCfg.Spec.Rate = cliCtx.Float64(v)
 	}
 	if v := "conns"; cliCtx.IsSet(v) || profileCfg.Spec.Conns == 0 {
 		profileCfg.Spec.Conns = cliCtx.Int(v)

--- a/request/client.go
+++ b/request/client.go
@@ -15,14 +15,14 @@ import (
 //
 // 1. Is it possible to build one http2 client with multiple connections?
 // 2. How to monitor HTTP2 GOAWAY frame?
-func NewClients(kubeCfgPath string, ConnsNum int, userAgent string, qps int, contentType string) ([]rest.Interface, error) {
+func NewClients(kubeCfgPath string, ConnsNum int, userAgent string, qps float64, contentType string) ([]rest.Interface, error) {
 	restCfg, err := clientcmd.BuildConfigFromFlags("", kubeCfgPath)
 	if err != nil {
 		return nil, err
 	}
 
 	if qps == 0 {
-		qps = math.MaxInt32
+		qps = float64(math.MaxInt32)
 	}
 	restCfg.QPS = float32(qps)
 	restCfg.NegotiatedSerializer = scheme.Codecs.WithoutConversion()

--- a/request/schedule.go
+++ b/request/schedule.go
@@ -38,9 +38,9 @@ func Schedule(ctx context.Context, spec *types.LoadProfileSpec, restCli []rest.I
 
 	qps := spec.Rate
 	if qps == 0 {
-		qps = math.MaxInt32
+		qps = float64(math.MaxInt32)
 	}
-	limiter := rate.NewLimiter(rate.Limit(qps), 10)
+	limiter := rate.NewLimiter(rate.Limit(qps), 1)
 
 	reqBuilderCh := rndReqs.Chan()
 	var wg sync.WaitGroup


### PR DESCRIPTION
With float64, we can setup burst heavy request, like list all pods. For example, --rate=0.1 means runner can send request per 10 seconds.