### PR TITLE
*: add --affinity flag to rg run

### DIFF
--- a/cmd/kperf/commands/runnergroup/run.go
+++ b/cmd/kperf/commands/runnergroup/run.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/kperf/api/types"
+	"github.com/Azure/kperf/cmd/kperf/commands/utils"
 	"github.com/Azure/kperf/runner"
 	runnergroup "github.com/Azure/kperf/runner/group"
 
@@ -31,11 +32,20 @@ var runCommand = cli.Command{
 			// Right now, we need to set image manually.
 			Required: true,
 		},
+		cli.StringSliceFlag{
+			Name:  "affinity",
+			Usage: "Deploy server to the node with a specific labels (FORMAT: KEY=VALUE[,VALUE])",
+		},
 	},
 	Action: func(cliCtx *cli.Context) error {
 		imgRef := cliCtx.String("runner-image")
 		if len(imgRef) == 0 {
 			return fmt.Errorf("required valid runner image")
+		}
+
+		affinityLabels, err := utils.KeyValuesMap(cliCtx.StringSlice("affinity"))
+		if err != nil {
+			return fmt.Errorf("failed to parse affinity: %w", err)
 		}
 
 		specs, err := loadRunnerGroupSpec(cliCtx)
@@ -51,6 +61,7 @@ var runCommand = cli.Command{
 			kubeCfgPath,
 			imgRef,
 			specs[0],
+			affinityLabels,
 		)
 	},
 }

--- a/cmd/kperf/commands/utils/helper.go
+++ b/cmd/kperf/commands/utils/helper.go
@@ -1,12 +1,12 @@
-package virtualcluster
+package utils
 
 import (
 	"fmt"
 	"strings"
 )
 
-// stringSliceToMap converts key=value[,value] into map[string][]string.
-func stringSliceToMap(strs []string) (map[string][]string, error) {
+// KeyValuesMap converts key=value[,value] into map[string][]string.
+func KeyValuesMap(strs []string) (map[string][]string, error) {
 	res := make(map[string][]string, len(strs))
 	for _, str := range strs {
 		key, valuesInStr, ok := strings.Cut(str, "=")

--- a/cmd/kperf/commands/virtualcluster/nodepool.go
+++ b/cmd/kperf/commands/virtualcluster/nodepool.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Azure/kperf/cmd/kperf/commands/utils"
 	"github.com/Azure/kperf/virtualcluster"
 
 	"github.com/urfave/cli"
@@ -62,7 +63,7 @@ var nodepoolAddCommand = cli.Command{
 
 		kubeCfgPath := cliCtx.String("kubeconfig")
 
-		affinityLabels, err := stringSliceToMap(cliCtx.StringSlice("affinity"))
+		affinityLabels, err := utils.KeyValuesMap(cliCtx.StringSlice("affinity"))
 		if err != nil {
 			return fmt.Errorf("failed to parse affinity: %w", err)
 		}

--- a/manifests/runnergroup/server/templates/pod.yaml
+++ b/manifests/runnergroup/server/templates/pod.yaml
@@ -4,6 +4,21 @@ metadata:
   name: {{ .Values.name }}
   namespace: {{ .Release.Namespace }}
 spec:
+{{- if .Values.nodeSelectors }}
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+  {{- range $key, $values := .Values.nodeSelectors }}
+          - key: "{{ $key }}"
+            operator: In
+            values:
+    {{- range $values }}
+              - {{ . }}
+    {{- end }}
+  {{- end }}
+{{- end }}
   containers:
   - name: server
     command:

--- a/manifests/runnergroup/server/values.yaml
+++ b/manifests/runnergroup/server/values.yaml
@@ -2,3 +2,4 @@ name: ""
 image: ""
 # TODO(weifu): need https://github.com/Azure/kperf/issues/25 to support list
 runnerGroupSpec: ""
+nodeSelectors: {}


### PR DESCRIPTION
It's used to run runner group's server in the node with specific labels.

Part of #34