### PR TITLE
*: add MaxRetries to loadprofile spec

### DIFF
--- a/api/types/load_traffic.go
+++ b/api/types/load_traffic.go
@@ -46,6 +46,10 @@ type LoadProfileSpec struct {
 	ContentType ContentType `json:"contentType" yaml:"contentType"`
 	// DisableHTTP2 means client will use HTTP/1.1 protocol if it's true.
 	DisableHTTP2 bool `json:"disableHTTP2" yaml:"disableHTTP2"`
+	// MaxRetries makes the request use the given integer as a ceiling of
+	// retrying upon receiving "Retry-After" headers and 429 status-code
+	// in the response (<= 0 means no retry).
+	MaxRetries int `json:"maxRetries" yaml:"maxRetries"`
 	// Requests defines the different kinds of requests with weights.
 	// The executor should randomly pick by weight.
 	Requests []*WeightedRequest

--- a/cmd/kperf/commands/runner/runner.go
+++ b/cmd/kperf/commands/runner/runner.go
@@ -72,6 +72,11 @@ var runCommand = cli.Command{
 			Name:  "disable-http2",
 			Usage: "Disable HTTP2 protocol",
 		},
+		cli.IntFlag{
+			Name:  "max-retries",
+			Usage: "Retry request after receiving 429 http code (<=0 means no retry)",
+			Value: 0,
+		},
 		cli.StringFlag{
 			Name:  "result",
 			Usage: "Path to the file which stores results",
@@ -169,6 +174,9 @@ func loadConfig(cliCtx *cli.Context) (*types.LoadProfile, error) {
 	}
 	if v := "disable-http2"; cliCtx.IsSet(v) {
 		profileCfg.Spec.DisableHTTP2 = cliCtx.Bool(v)
+	}
+	if v := "max-retries"; cliCtx.IsSet(v) {
+		profileCfg.Spec.MaxRetries = cliCtx.Int(v)
 	}
 
 	if err := profileCfg.Validate(); err != nil {


### PR DESCRIPTION
By default, we should set MaxRetries to zero. NoRetry can help us verify the flowcontrol settings.

Closes: #53