### PR TITLE
metrics: fix missing timeout errors

### DIFF
--- a/metrics/utils.go
+++ b/metrics/utils.go
@@ -126,6 +126,8 @@ func updateNetErrors(stats *types.ResponseErrorStats, err error) {
 			stats.NetErrors[errNetIOTimeout.Error()]++
 		case strings.Contains(errInStr, errTLSHandshakeTimeout.Error()):
 			stats.NetErrors[errTLSHandshakeTimeout.Error()]++
+		default:
+			stats.NetErrors[err.Error()]++
 		}
 	case errors.Is(err, io.ErrUnexpectedEOF):
 		stats.NetErrors[io.ErrUnexpectedEOF.Error()]++


### PR DESCRIPTION
```json
{
  "errorStats": {
    "unknownErrors": [],
    "netErrors": {
      "Get \"https://10.100.0.1:443/api/v1/pods?timeout=1m0s\": dial tcp 10.100.0.1:443: i/o timeout": 120,
      "i/o timeout": 3517,
      "net/http: TLS handshake timeout": 6246
    },
    "responseCodes": {},
    "http2Errors": {
      "connectionErrors": {
        "http2: client connection lost": 5075
      }
    }
  }
}
```