### PR TITLE
.github: add image-build in action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,5 @@ jobs:
           go-version: "1.21"
       - name: build
         run: make build
+      - name: image-build
+        run: make image-build


### PR DESCRIPTION
Just in case that we forgot to update go-version in Dockerfile