### PR TITLE
helmcli: ignore not found error on delete

### DIFF
--- a/helmcli/delete.go
+++ b/helmcli/delete.go
@@ -1,9 +1,11 @@
 package helmcli
 
 import (
+	"errors"
 	"fmt"
 
 	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/storage/driver"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
@@ -37,5 +39,8 @@ func NewDeleteCli(kubeconfigPath string, namespace string) (*DeleteCli, error) {
 func (cli *DeleteCli) Delete(releaseName string) error {
 	delCli := action.NewUninstall(cli.cfg)
 	_, err := delCli.Run(releaseName)
+	if errors.Is(err, driver.ErrReleaseNotFound) {
+		err = nil
+	}
 	return err
 }


### PR DESCRIPTION
If there is no such release, we should just ignore that. It's hard to handle error message in command-line. If the end-user wants to show error for 404, let's revert this and add flag for each command-line for skip.