### PR TITLE
contrib: update ekswarmup.yaml

### DIFF
--- a/contrib/cmd/runkperf/commands/ekswarmup/command.go
+++ b/contrib/cmd/runkperf/commands/ekswarmup/command.go
@@ -159,8 +159,7 @@ func deployWarmupRunnerGroup(ctx context.Context, kubeCfgPath string, runnerImag
 		klog.V(0).ErrorS(derr, "failed to delete existing runner group")
 	}
 
-	rerr := kr.RGRun(ctx, 0, rgCfgFile, "exempt:5",
-		fmt.Sprintf("node.kubernetes.io/instance-type=%v", utils.EKSRunnerNodepoolInstanceType))
+	rerr := kr.RGRun(ctx, 0, rgCfgFile, "workload-low:1000", "")
 	if rerr != nil {
 		return fmt.Errorf("failed to deploy warmup runner group: %w", rerr)
 	}

--- a/contrib/internal/manifests/loadprofile/ekswarmup.yaml
+++ b/contrib/internal/manifests/loadprofile/ekswarmup.yaml
@@ -3,7 +3,7 @@ loadProfile:
   version: 1
   description: "warmup"
   spec:
-    rate: 10
+    rate: 20
     total: 10000
     conns: 10
     client: 100


### PR DESCRIPTION
Increases rate and uses flowcontrol. It would be easy to force eks to use 16 cores.