### PR TITLE
contrib/internal/manifests: remove limit for staleList

### DIFF
--- a/contrib/internal/manifests/loadprofile/ekswarmup.yaml
+++ b/contrib/internal/manifests/loadprofile/ekswarmup.yaml
@@ -14,7 +14,6 @@ loadProfile:
       - staleList:
           version: v1
           resource: pods
-          limit: 500
         shares: 1000 # chance 1000 / (1000 + 100 + 100)
       - quorumList:
           version: v1

--- a/contrib/internal/manifests/loadprofile/node100_job1_pod3k.yaml
+++ b/contrib/internal/manifests/loadprofile/node100_job1_pod3k.yaml
@@ -14,7 +14,6 @@ loadProfile:
       - staleList:
           version: v1
           resource: pods
-          limit: 500
         shares: 1000 # chance 1000 / (1000 + 100 + 100)
       - quorumList:
           version: v1


### PR DESCRIPTION
The kube-apiserver doesn't handle pagination for stale list.