### PR TITLE
manifests/virtualcluster/nodecontrollers: use system flowcontrol

### DIFF
--- a/manifests/virtualcluster/nodecontrollers/templates/flowcontrol.yaml
+++ b/manifests/virtualcluster/nodecontrollers/templates/flowcontrol.yaml
@@ -1,0 +1,27 @@
+apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
+kind: FlowSchema
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  distinguisherMethod:
+    type: ByUser
+  matchingPrecedence: 500
+  priorityLevelConfiguration:
+    name: system
+  rules:
+  - resourceRules:
+    - apiGroups:
+      - '*'
+      clusterScope: true
+      namespaces:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - '*'
+    subjects:
+    - kind: ServiceAccount
+      serviceAccount:
+        name: {{ .Values.name }}
+        namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
It's align with system:nodes:<node-name> users, like kubelet