### PR TITLE
*: refactor error stats

### DIFF
--- a/cmd/kperf/commands/runner/runner.go
+++ b/cmd/kperf/commands/runner/runner.go
@@ -192,7 +192,7 @@ func loadConfig(cliCtx *cli.Context) (*types.LoadProfile, error) {
 func printResponseStats(f *os.File, rawDataFlagIncluded bool, stats *request.Result) error {
 	output := types.RunnerMetricReport{
 		Total:              stats.Total,
-		ErrorStats:         stats.ErrorStats,
+		ErrorStats:         metrics.BuildErrorStatsGroupByType(stats.Errors),
 		Duration:           stats.Duration.String(),
 		TotalReceivedBytes: stats.TotalReceivedBytes,
 
@@ -215,6 +215,7 @@ func printResponseStats(f *os.File, rawDataFlagIncluded bool, stats *request.Res
 
 	if rawDataFlagIncluded {
 		output.LatenciesByURL = stats.LatenciesByURL
+		output.Errors = stats.Errors
 	}
 
 	encoder := json.NewEncoder(f)

--- a/request/schedule.go
+++ b/request/schedule.go
@@ -104,11 +104,12 @@ func Schedule(ctx context.Context, spec *types.LoadProfileSpec, restCli []rest.I
 							err = nil
 						}
 					}
-					latency := time.Since(start).Seconds()
+					end := time.Now()
+					latency := end.Sub(start).Seconds()
 
 					respMetric.ObserveReceivedBytes(bytes)
 					if err != nil {
-						respMetric.ObserveFailure(err)
+						respMetric.ObserveFailure(end, latency, err)
 						klog.V(5).Infof("Request stream failed: %v", err)
 						return
 					}


### PR DESCRIPTION
Introduce ResponseError type to record error client received. It includes timestamp, timespan in seconds and error message. The RunnerMetricReport will export raw data about each response error. It can help us build view about error.

```go
// ResponseError is the record about that error.
type ResponseError struct {
       // Timestamp indicates when this error was received.
       Timestamp time.Time `json:"timestamp"`
       // Duration records timespan in seconds.
       Duration float64 `json:"duration"`
       // Type indicates that category to which the error belongs.
       Type ResponseErrorType `json:"type"`
       // Code only works when Type is http.
       Code int `json:"code,omitempty"`
       // Message shows error message for this error.
       //
       // NOTE: When Type is http, this field will be empty.
       Message string `json:"message,omitempty"`
}
```