### PR TITLE
fix runkperf ignoring reqs total from spec

### DIFF
--- a/contrib/cmd/runkperf/commands/bench/utils.go
+++ b/contrib/cmd/runkperf/commands/bench/utils.go
@@ -145,7 +145,9 @@ func newLoadProfileFromEmbed(cliCtx *cli.Context, name string) (_name string, _s
 				return fmt.Errorf("failed to parse %s affinity: %w", rgAffinity, err)
 			}
 
-			spec.Profile.Spec.Total = reqs
+			if reqs != 0 {
+				spec.Profile.Spec.Total = reqs
+			}
 			spec.NodeAffinity = affinityLabels
 			spec.Profile.Spec.ContentType = types.ContentType(cliCtx.String("content-type"))
 			data, _ := yaml.Marshal(spec)


### PR DESCRIPTION
runkperf bench always set the total to the value of the cli arg "total". When this isn't specified, a default value of 1000 was used regardless of what was configured in the spec.

Fix it by using the CLI arg value only if it's non-zero.