### PR TITLE
*: add unstructuredscheme pkg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	k8s.io/cli-runtime v0.31.1
 	k8s.io/client-go v0.31.1
 	k8s.io/klog/v2 v2.130.1
-	k8s.io/kubectl v0.31.1
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
 	sigs.k8s.io/yaml v1.4.0
 )
@@ -145,6 +144,7 @@ require (
 	k8s.io/apiserver v0.31.1 // indirect
 	k8s.io/component-base v0.31.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
+	k8s.io/kubectl v0.31.1 // indirect
 	oras.land/oras-go v1.2.5 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kustomize/api v0.17.2 // indirect

--- a/request/client.go
+++ b/request/client.go
@@ -9,10 +9,10 @@ import (
 	"net/http"
 
 	"github.com/Azure/kperf/api/types"
+	"github.com/Azure/kperf/request/unstructuredscheme"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/kubectl/pkg/scheme"
 )
 
 // NewClients creates N rest.Interface.
@@ -31,7 +31,7 @@ func NewClients(kubeCfgPath string, connsNum int, opts ...ClientCfgOpt) ([]rest.
 	if err != nil {
 		return nil, err
 	}
-	restCfg.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	restCfg.NegotiatedSerializer = unstructuredscheme.NewNegotiatedSerializer()
 
 	// NOTE:
 	//

--- a/request/unstructuredscheme/serializer.go
+++ b/request/unstructuredscheme/serializer.go
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package unstructuredscheme
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+)
+
+var (
+	scheme = runtime.NewScheme()
+)
+
+func init() {
+	metav1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
+}
+
+func NewNegotiatedSerializer() runtime.NegotiatedSerializer {
+	return &negotiatedSerializer{}
+}
+
+type negotiatedSerializer struct{}
+
+func (s negotiatedSerializer) SupportedMediaTypes() []runtime.SerializerInfo {
+	return []runtime.SerializerInfo{
+		{
+			MediaType:        "application/json",
+			MediaTypeType:    "application",
+			MediaTypeSubType: "json",
+			EncodesAsText:    true,
+			Serializer:       json.NewSerializer(json.DefaultMetaFactory, creator{scheme}, typer{scheme}, false),
+			StreamSerializer: &runtime.StreamSerializerInfo{
+				EncodesAsText: true,
+				Serializer:    json.NewSerializer(json.DefaultMetaFactory, scheme, scheme, false),
+				Framer:        json.Framer,
+			},
+		},
+	}
+}
+
+func (s negotiatedSerializer) EncoderForVersion(encoder runtime.Encoder, gv runtime.GroupVersioner) runtime.Encoder {
+	return runtime.WithVersionEncoder{
+		Version:     gv,
+		Encoder:     encoder,
+		ObjectTyper: typer{scheme},
+	}
+}
+
+func (s negotiatedSerializer) DecoderToVersion(decoder runtime.Decoder, _ runtime.GroupVersioner) runtime.Decoder {
+	return decoder
+}
+
+type creator struct {
+	objCreator runtime.ObjectCreater
+}
+
+func (c creator) New(kind schema.GroupVersionKind) (runtime.Object, error) {
+	obj, err := c.objCreator.New(kind)
+	if err == nil {
+		return obj, nil
+	}
+
+	obj = &unstructured.Unstructured{}
+	obj.GetObjectKind().SetGroupVersionKind(kind)
+	return obj, nil
+}
+
+type typer struct {
+	typer runtime.ObjectTyper
+}
+
+func (t typer) ObjectKinds(obj runtime.Object) ([]schema.GroupVersionKind, bool, error) {
+	kinds, unversioned, err := t.typer.ObjectKinds(obj)
+	if err == nil {
+		return kinds, unversioned, nil
+	}
+
+	if _, ok := obj.(runtime.Unstructured); ok && !obj.GetObjectKind().GroupVersionKind().Empty() {
+		return []schema.GroupVersionKind{obj.GetObjectKind().GroupVersionKind()}, false, nil
+	}
+	return nil, false, err
+}
+
+func (t typer) Recognizes(_ schema.GroupVersionKind) bool {
+	return true
+}


### PR DESCRIPTION
When client receives watch event for CustomResources, we need to use unstructured to unmarshal event object. Otherwise, we run into the issue, like

```bash
 Request stream failed: an error on the server ("unable to decode an event from
 the watch stream: unable to decode watch event: no kind \"NodeNetworkConfig\"
 is registered for version \"acn.azure.com/v1alpha\" in scheme
 \"pkg/runtime/scheme.go:100\"") has prevented the request from succeeding
```

It's only used for watch list requests, since get/list responses will be discarded and there is no need to do serialization.