### PR TITLE
Add a new runkperf bench for listing configmaps

### DIFF
--- a/api/types/load_traffic.go
+++ b/api/types/load_traffic.go
@@ -182,7 +182,7 @@ func (spec LoadProfileSpec) Validate() error {
 	}
 
 	if spec.Total <= 0 && spec.Duration <= 0 {
-		return fmt.Errorf("total requires > 0: %v", spec.Total)
+		return fmt.Errorf("total requires > 0: %v or duration > 0s: %v", spec.Total, spec.Duration)
 	}
 
 	if spec.Client <= 0 {

--- a/api/types/load_traffic.go
+++ b/api/types/load_traffic.go
@@ -41,7 +41,7 @@ type LoadProfileSpec struct {
 	Rate float64 `json:"rate" yaml:"rate"`
 	// Total defines the total number of requests.
 	Total int `json:"total" yaml:"total"`
-	// Conns defines total number of long connections used for traffic.
+	// TotalTime defines the total running time in seconds (zero is no limit).
 	TotalTime int `json:"total_time" yaml:"total_time"`
 	// Conns defines total number of long connections used for traffic.
 	Conns int `json:"conns" yaml:"conns"`

--- a/api/types/load_traffic.go
+++ b/api/types/load_traffic.go
@@ -42,6 +42,8 @@ type LoadProfileSpec struct {
 	// Total defines the total number of requests.
 	Total int `json:"total" yaml:"total"`
 	// Conns defines total number of long connections used for traffic.
+	TotalTime int `json:"total_time" yaml:"total_time"`
+	// Conns defines total number of long connections used for traffic.
 	Conns int `json:"conns" yaml:"conns"`
 	// Client defines total number of HTTP clients.
 	Client int `json:"client" yaml:"client"`
@@ -179,7 +181,7 @@ func (spec LoadProfileSpec) Validate() error {
 		return fmt.Errorf("rate requires >= 0: %v", spec.Rate)
 	}
 
-	if spec.Total <= 0 {
+	if spec.Total <= 0 && spec.TotalTime <= 0 {
 		return fmt.Errorf("total requires > 0: %v", spec.Total)
 	}
 

--- a/api/types/load_traffic.go
+++ b/api/types/load_traffic.go
@@ -41,8 +41,8 @@ type LoadProfileSpec struct {
 	Rate float64 `json:"rate" yaml:"rate"`
 	// Total defines the total number of requests.
 	Total int `json:"total" yaml:"total"`
-	// TotalTime defines the total running time in seconds (zero is no limit).
-	TotalTime int `json:"total_time" yaml:"total_time"`
+	// Duration defines the running time in seconds.
+	Duration int `json:"duration" yaml:"duration"`
 	// Conns defines total number of long connections used for traffic.
 	Conns int `json:"conns" yaml:"conns"`
 	// Client defines total number of HTTP clients.
@@ -181,7 +181,7 @@ func (spec LoadProfileSpec) Validate() error {
 		return fmt.Errorf("rate requires >= 0: %v", spec.Rate)
 	}
 
-	if spec.Total <= 0 && spec.TotalTime <= 0 {
+	if spec.Total <= 0 && spec.Duration <= 0 {
 		return fmt.Errorf("total requires > 0: %v", spec.Total)
 	}
 

--- a/cmd/kperf/commands/runner/runner.go
+++ b/cmd/kperf/commands/runner/runner.go
@@ -88,6 +88,11 @@ var runCommand = cli.Command{
 			Name:  "raw-data",
 			Usage: "show raw letencies data in result",
 		},
+		cli.IntFlag{
+			Name:  "total-time",
+			Usage: "Total time for runner to run. Unit is Sec. It will be ignored if --total is set.",
+			Value: 0,
+		},
 	},
 	Action: func(cliCtx *cli.Context) error {
 		kubeCfgPath := cliCtx.String("kubeconfig")
@@ -168,6 +173,15 @@ func loadConfig(cliCtx *cli.Context) (*types.LoadProfile, error) {
 	}
 	if v := "client"; cliCtx.IsSet(v) || profileCfg.Spec.Client == 0 {
 		profileCfg.Spec.Client = cliCtx.Int(v)
+	}
+	if v := "total"; !cliCtx.IsSet(v) && profileCfg.Spec.Total == 0 {
+		if v := "total-time"; cliCtx.IsSet(v) {
+			profileCfg.Spec.TotalTime = cliCtx.Int(v)
+		}
+		if profileCfg.Spec.TotalTime > 0 {
+			// Setting Total to -1 to indicate that TotalTime is being used
+			profileCfg.Spec.Total = -1
+		}
 	}
 	if v := "total"; cliCtx.IsSet(v) || profileCfg.Spec.Total == 0 {
 		profileCfg.Spec.Total = cliCtx.Int(v)

--- a/cmd/kperf/commands/runner/runner.go
+++ b/cmd/kperf/commands/runner/runner.go
@@ -89,8 +89,8 @@ var runCommand = cli.Command{
 			Usage: "show raw letencies data in result",
 		},
 		cli.IntFlag{
-			Name:  "total-time",
-			Usage: "Total time for runner to run. Unit is Sec. It will be ignored if --total is set.",
+			Name:  "duration-sec",
+			Usage: "Duration of the benchmark in seconds. It will be ignored if --total is set.",
 			Value: 0,
 		},
 	},
@@ -175,11 +175,11 @@ func loadConfig(cliCtx *cli.Context) (*types.LoadProfile, error) {
 		profileCfg.Spec.Client = cliCtx.Int(v)
 	}
 	if v := "total"; !cliCtx.IsSet(v) && profileCfg.Spec.Total == 0 {
-		if v := "total-time"; cliCtx.IsSet(v) {
-			profileCfg.Spec.TotalTime = cliCtx.Int(v)
+		if v := "duration"; cliCtx.IsSet(v) {
+			profileCfg.Spec.Duration = cliCtx.Int(v)
 		}
-		if profileCfg.Spec.TotalTime > 0 {
-			// Setting Total to -1 to indicate that TotalTime is being used
+		if profileCfg.Spec.Duration > 0 {
+			// Setting Total to -1 to indicate that Duration is being used
 			profileCfg.Spec.Total = -1
 		}
 	}

--- a/cmd/kperf/commands/runner/runner.go
+++ b/cmd/kperf/commands/runner/runner.go
@@ -89,7 +89,7 @@ var runCommand = cli.Command{
 			Usage: "show raw letencies data in result",
 		},
 		cli.IntFlag{
-			Name:  "duration-sec",
+			Name:  "duration",
 			Usage: "Duration of the benchmark in seconds. It will be ignored if --total is set.",
 			Value: 0,
 		},

--- a/cmd/kperf/commands/runner/runner.go
+++ b/cmd/kperf/commands/runner/runner.go
@@ -174,17 +174,14 @@ func loadConfig(cliCtx *cli.Context) (*types.LoadProfile, error) {
 	if v := "client"; cliCtx.IsSet(v) || profileCfg.Spec.Client == 0 {
 		profileCfg.Spec.Client = cliCtx.Int(v)
 	}
-	if v := "total"; !cliCtx.IsSet(v) && profileCfg.Spec.Total == 0 {
-		if v := "duration"; cliCtx.IsSet(v) {
-			profileCfg.Spec.Duration = cliCtx.Int(v)
-		}
-		if profileCfg.Spec.Duration > 0 {
-			// Setting Total to -1 to indicate that Duration is being used
-			profileCfg.Spec.Total = -1
-		}
-	}
-	if v := "total"; cliCtx.IsSet(v) || profileCfg.Spec.Total == 0 {
+	if v := "total"; cliCtx.IsSet(v) {
 		profileCfg.Spec.Total = cliCtx.Int(v)
+	}
+	if v := "duration"; cliCtx.IsSet(v) {
+		profileCfg.Spec.Duration = cliCtx.Int(v)
+	}
+	if profileCfg.Spec.Total == 0 && profileCfg.Spec.Duration == 0 {
+		profileCfg.Spec.Total = cliCtx.Int("total")
 	}
 	if v := "content-type"; cliCtx.IsSet(v) || profileCfg.Spec.ContentType == "" {
 		profileCfg.Spec.ContentType = types.ContentType(cliCtx.String(v))

--- a/cmd/kperf/commands/runner/runner.go
+++ b/cmd/kperf/commands/runner/runner.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Azure/kperf/cmd/kperf/commands/utils"
 	"github.com/Azure/kperf/metrics"
 	"github.com/Azure/kperf/request"
+	"k8s.io/klog/v2"
 
 	"github.com/urfave/cli"
 	"gopkg.in/yaml.v2"
@@ -181,8 +182,8 @@ func loadConfig(cliCtx *cli.Context) (*types.LoadProfile, error) {
 		profileCfg.Spec.Duration = cliCtx.Int(v)
 	}
 	if profileCfg.Spec.Total > 0 && profileCfg.Spec.Duration > 0 {
+		klog.Warningf("both total:%v and duration:%v are set, duration will be ignored\n", profileCfg.Spec.Total, profileCfg.Spec.Duration)
 		profileCfg.Spec.Duration = 0
-		fmt.Printf("Warning: both total:%v and duration:%v are set, duration will be ignored\n", profileCfg.Spec.Total, profileCfg.Spec.Duration)
 	}
 	if profileCfg.Spec.Total == 0 && profileCfg.Spec.Duration == 0 {
 		// Use default total value

--- a/cmd/kperf/commands/runner/runner.go
+++ b/cmd/kperf/commands/runner/runner.go
@@ -180,7 +180,12 @@ func loadConfig(cliCtx *cli.Context) (*types.LoadProfile, error) {
 	if v := "duration"; cliCtx.IsSet(v) {
 		profileCfg.Spec.Duration = cliCtx.Int(v)
 	}
+	if profileCfg.Spec.Total > 0 && profileCfg.Spec.Duration > 0 {
+		profileCfg.Spec.Duration = 0
+		fmt.Printf("Warning: both total:%v and duration:%v are set, duration will be ignored\n", profileCfg.Spec.Total, profileCfg.Spec.Duration)
+	}
 	if profileCfg.Spec.Total == 0 && profileCfg.Spec.Duration == 0 {
+		// Use default total value
 		profileCfg.Spec.Total = cliCtx.Int("total")
 	}
 	if v := "content-type"; cliCtx.IsSet(v) || profileCfg.Spec.ContentType == "" {

--- a/contrib/cmd/runkperf/commands/bench/list_configmaps.go
+++ b/contrib/cmd/runkperf/commands/bench/list_configmaps.go
@@ -39,7 +39,7 @@ The test suite is to generate configmaps in a namespace and list them. The load 
 		cli.IntFlag{
 			Name:  "total",
 			Usage: "Total requests per runner (There are 10 runners totally and runner's rate is 10)",
-			Value: 0,
+			Value: 1000,
 		},
 		cli.IntFlag{
 			Name:  "duration-sec",

--- a/contrib/cmd/runkperf/commands/bench/list_configmaps.go
+++ b/contrib/cmd/runkperf/commands/bench/list_configmaps.go
@@ -42,7 +42,7 @@ The test suite is to generate configmaps in a namespace and list them. The load 
 			Value: 1000,
 		},
 		cli.IntFlag{
-			Name:  "duration-sec",
+			Name:  "duration",
 			Usage: "Duration of the benchmark in seconds. It will be ignored if --total is set.",
 			Value: 0,
 		},

--- a/contrib/cmd/runkperf/commands/bench/list_configmaps.go
+++ b/contrib/cmd/runkperf/commands/bench/list_configmaps.go
@@ -99,7 +99,7 @@ func benchListConfigmapsRun(cliCtx *cli.Context) (*internaltypes.BenchmarkReport
 	dpCtx, dpCancel := context.WithCancel(ctx)
 	defer dpCancel()
 
-	duration := cliCtx.Duration("duration-sec")
+	duration := cliCtx.Duration("duration")
 	if duration != 0 {
 		log.GetLogger(dpCtx).
 			WithKeyValues("level", "info").

--- a/contrib/cmd/runkperf/commands/bench/list_configmaps.go
+++ b/contrib/cmd/runkperf/commands/bench/list_configmaps.go
@@ -82,7 +82,13 @@ func benchConfigmapsRun(cliCtx *cli.Context) (*internaltypes.BenchmarkReport, er
 
 	defer func() {
 		// Delete the configmaps after the benchmark
-		utils.DeleteConfigmaps(ctx, kubeCfgPath, benchConfigmapNamespace, 0)
+		err = utils.DeleteConfigmaps(ctx, kubeCfgPath, benchConfigmapNamespace, 0)
+		if err != nil {
+			log.GetLogger(ctx).WithKeyValues("level", "error").
+				LogKV("msg", fmt.Sprintf("Failed to delete configmaps: %v", err))
+		}
+
+		// Delete the namespace after the benchmark
 		kr := utils.NewKubectlRunner(kubeCfgPath, benchConfigmapNamespace)
 		err := kr.DeleteNamespace(ctx, 0, benchConfigmapNamespace)
 		if err != nil {

--- a/contrib/cmd/runkperf/commands/bench/list_configmaps.go
+++ b/contrib/cmd/runkperf/commands/bench/list_configmaps.go
@@ -14,7 +14,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-var benchConfigmapsCase = cli.Command{
+var benchListConfigmapsCase = cli.Command{
 	Name: "list_configmaps",
 	Usage: `
 
@@ -50,7 +50,7 @@ in a namespace and list them. The load profile is fixed.
 	},
 	Action: func(cliCtx *cli.Context) error {
 		_, err := renderBenchmarkReportInterceptor(
-			addAPIServerCoresInfoInterceptor(benchConfigmapsRun),
+			addAPIServerCoresInfoInterceptor(benchListConfigmapsRun),
 		)(cliCtx)
 		return err
 	},
@@ -59,7 +59,7 @@ in a namespace and list them. The load profile is fixed.
 var benchConfigmapNamespace = "kperf-configmaps-bench"
 
 // benchfigmapsCase is for subcommand benchConfigmapsCase.
-func benchConfigmapsRun(cliCtx *cli.Context) (*internaltypes.BenchmarkReport, error) {
+func benchListConfigmapsRun(cliCtx *cli.Context) (*internaltypes.BenchmarkReport, error) {
 	ctx := context.Background()
 	kubeCfgPath := cliCtx.GlobalString("kubeconfig")
 

--- a/contrib/cmd/runkperf/commands/bench/list_configmaps.go
+++ b/contrib/cmd/runkperf/commands/bench/list_configmaps.go
@@ -42,8 +42,8 @@ The test suite is to generate configmaps in a namespace and list them. The load 
 			Value: 0,
 		},
 		cli.IntFlag{
-			Name:  "total-time",
-			Usage: "Total time to run the benchmark. Unit is Sec. It will be ignored if --total is set.",
+			Name:  "duration-sec",
+			Usage: "Duration of the benchmark in seconds. It will be ignored if --total is set.",
 			Value: 0,
 		},
 	},
@@ -99,11 +99,11 @@ func benchListConfigmapsRun(cliCtx *cli.Context) (*internaltypes.BenchmarkReport
 	dpCtx, dpCancel := context.WithCancel(ctx)
 	defer dpCancel()
 
-	totalTime := cliCtx.Duration("total-time")
-	if totalTime != 0 {
+	duration := cliCtx.Duration("duration-sec")
+	if duration != 0 {
 		log.GetLogger(dpCtx).
 			WithKeyValues("level", "info").
-			LogKV("msg", fmt.Sprintf("Running for %v seconds", totalTime.Seconds()))
+			LogKV("msg", fmt.Sprintf("Running for %v seconds", duration.Seconds()))
 	}
 
 	rgResult, derr := utils.DeployRunnerGroup(ctx,
@@ -128,7 +128,7 @@ Workload: List all configmaps in the namespace and get the percentile latency.`,
 		Result:   *rgResult,
 		Info: map[string]interface{}{
 			"configmapSizeInBytes": cmSize,
-			"runningTime":          totalTime.String(),
+			"runningTime":          duration.String(),
 		},
 	}, nil
 }

--- a/contrib/cmd/runkperf/commands/bench/list_configmaps.go
+++ b/contrib/cmd/runkperf/commands/bench/list_configmaps.go
@@ -1,0 +1,129 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package bench
+
+import (
+	"context"
+	"fmt"
+
+	internaltypes "github.com/Azure/kperf/contrib/internal/types"
+	"github.com/Azure/kperf/contrib/log"
+	"github.com/Azure/kperf/contrib/utils"
+
+	"github.com/urfave/cli"
+)
+
+var benchConfigmapsCase = cli.Command{
+	Name: "list_configmaps",
+	Usage: `
+
+The test suite is to generate configmaps and list them. It will create configmaps 
+in a namespace and list them. The load profile is fixed.
+	`,
+	Flags: []cli.Flag{
+		cli.IntFlag{
+			Name:  "size",
+			Usage: "The size of each configmap",
+			Value: 20,
+		},
+		cli.IntFlag{
+			Name:  "group-size",
+			Usage: "The size of each configmap group",
+			Value: 100,
+		},
+		cli.IntFlag{
+			Name:  "configmap-amount",
+			Usage: "Total amount of configmaps",
+			Value: 1024,
+		},
+		cli.IntFlag{
+			Name:  "total",
+			Usage: "Total requests per runner (There are 10 runners totally and runner's rate is 10)",
+			Value: 0,
+		},
+		cli.IntFlag{
+			Name:  "total-time",
+			Usage: "Total time to run the benchmark. Unit is Sec. It will be ignored if --total is set.",
+			Value: 0,
+		},
+	},
+	Action: func(cliCtx *cli.Context) error {
+		_, err := renderBenchmarkReportInterceptor(
+			addAPIServerCoresInfoInterceptor(benchConfigmapsRun),
+		)(cliCtx)
+		return err
+	},
+}
+
+var benchConfigmapNamespace = "kperf-configmaps-bench"
+
+// benchfigmapsCase is for subcommand benchConfigmapsCase.
+func benchConfigmapsRun(cliCtx *cli.Context) (*internaltypes.BenchmarkReport, error) {
+	ctx := context.Background()
+	kubeCfgPath := cliCtx.GlobalString("kubeconfig")
+
+	rgCfgFile, rgSpec, rgCfgFileDone, err := newLoadProfileFromEmbed(cliCtx,
+		"loadprofile/list_configmaps.yaml")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rgCfgFileDone() }()
+
+	// Create a namespace for the benchmark
+	cmAmount := cliCtx.Int("configmap-amount")
+	cmSize := cliCtx.Int("size")
+	cmGroupSize := cliCtx.Int("group-size")
+
+	err = utils.CreateConfigmaps(ctx, kubeCfgPath, cmAmount, cmSize, cmGroupSize, benchConfigmapNamespace, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		// Delete the configmaps after the benchmark
+		utils.DeleteConfigmaps(ctx, kubeCfgPath, benchConfigmapNamespace, 0)
+		kr := utils.NewKubectlRunner(kubeCfgPath, benchConfigmapNamespace)
+		err := kr.DeleteNamespace(ctx, 0, benchConfigmapNamespace)
+		if err != nil {
+			log.GetLogger(ctx).WithKeyValues("level", "error").
+				LogKV("msg", fmt.Sprintf("Failed to delete namespace: %v", err))
+		}
+	}()
+
+	dpCtx, dpCancel := context.WithCancel(ctx)
+	defer dpCancel()
+
+	totalTime := cliCtx.Duration("total-time")
+	if totalTime != 0 {
+		log.GetLogger(dpCtx).
+			WithKeyValues("level", "info").
+			LogKV("msg", fmt.Sprintf("Running for %v seconds", totalTime.Seconds()))
+	}
+
+	rgResult, derr := utils.DeployRunnerGroup(ctx,
+		cliCtx.GlobalString("kubeconfig"),
+		cliCtx.GlobalString("runner-image"),
+		rgCfgFile,
+		cliCtx.GlobalString("runner-flowcontrol"),
+		cliCtx.GlobalString("rg-affinity"),
+	)
+
+	if derr != nil {
+		return nil, derr
+	}
+
+	return &internaltypes.BenchmarkReport{
+		Description: fmt.Sprintf(`
+Environment: Generate %v configmaps with %v bytes each in a namespace.
+Workload: List all configmaps in the namespace and get the percentile latency.`,
+			cmAmount, cmSize),
+
+		LoadSpec: *rgSpec,
+		Result:   *rgResult,
+		Info: map[string]interface{}{
+			"configmapSizeInBytes": cmSize,
+			"runningTime":          totalTime.String(),
+		},
+	}, nil
+}

--- a/contrib/cmd/runkperf/commands/bench/list_configmaps.go
+++ b/contrib/cmd/runkperf/commands/bench/list_configmaps.go
@@ -18,8 +18,7 @@ var benchListConfigmapsCase = cli.Command{
 	Name: "list_configmaps",
 	Usage: `
 
-The test suite is to generate configmaps and list them. It will create configmaps 
-in a namespace and list them. The load profile is fixed.
+The test suite is to generate configmaps in a namespace and list them. The load profile is fixed.
 	`,
 	Flags: []cli.Flag{
 		cli.IntFlag{

--- a/contrib/cmd/runkperf/commands/bench/list_configmaps.go
+++ b/contrib/cmd/runkperf/commands/bench/list_configmaps.go
@@ -24,8 +24,8 @@ in a namespace and list them. The load profile is fixed.
 	Flags: []cli.Flag{
 		cli.IntFlag{
 			Name:  "size",
-			Usage: "The size of each configmap",
-			Value: 20,
+			Usage: "The size of each configmap (Unit: KiB)",
+			Value: 100,
 		},
 		cli.IntFlag{
 			Name:  "group-size",

--- a/contrib/cmd/runkperf/commands/bench/root.go
+++ b/contrib/cmd/runkperf/commands/bench/root.go
@@ -59,6 +59,7 @@ var Command = cli.Command{
 		benchNode100Job1Pod3KCase,
 		benchNode100DeploymentNPod10KCase,
 		benchCiliumCustomResourceListCase,
+		benchConfigmapsCase,
 	},
 }
 

--- a/contrib/cmd/runkperf/commands/bench/root.go
+++ b/contrib/cmd/runkperf/commands/bench/root.go
@@ -59,7 +59,7 @@ var Command = cli.Command{
 		benchNode100Job1Pod3KCase,
 		benchNode100DeploymentNPod10KCase,
 		benchCiliumCustomResourceListCase,
-		benchConfigmapsCase,
+		benchListConfigmapsCase,
 	},
 }
 

--- a/contrib/cmd/runkperf/commands/bench/utils.go
+++ b/contrib/cmd/runkperf/commands/bench/utils.go
@@ -150,9 +150,9 @@ func newLoadProfileFromEmbed(cliCtx *cli.Context, name string) (_name string, _s
 			if reqs < 0 {
 				return fmt.Errorf("invalid total-requests value: %v", reqs)
 			}
-			reqsTime := cliCtx.Int("total-time")
+			reqsTime := cliCtx.Int("duration-sec")
 			if reqs == 0 && reqsTime != 0 {
-				spec.Profile.Spec.TotalTime = reqsTime
+				spec.Profile.Spec.Duration = reqsTime
 			}
 
 			rgAffinity := cliCtx.GlobalString("rg-affinity")

--- a/contrib/cmd/runkperf/commands/bench/utils.go
+++ b/contrib/cmd/runkperf/commands/bench/utils.go
@@ -150,8 +150,9 @@ func newLoadProfileFromEmbed(cliCtx *cli.Context, name string) (_name string, _s
 			if reqs < 0 {
 				return fmt.Errorf("invalid total-requests value: %v", reqs)
 			}
-			reqsTime := cliCtx.Int("duration-sec")
-			if reqs == 0 && reqsTime != 0 {
+			reqsTime := cliCtx.Int("duration")
+			if !cliCtx.IsSet("total") && reqsTime > 0 {
+				reqs = 0
 				spec.Profile.Spec.Duration = reqsTime
 			}
 

--- a/contrib/cmd/runkperf/commands/bench/utils.go
+++ b/contrib/cmd/runkperf/commands/bench/utils.go
@@ -150,6 +150,10 @@ func newLoadProfileFromEmbed(cliCtx *cli.Context, name string) (_name string, _s
 			if reqs < 0 {
 				return fmt.Errorf("invalid total-requests value: %v", reqs)
 			}
+			reqsTime := cliCtx.Int("total-time")
+			if reqs == 0 && reqsTime != 0 {
+				spec.Profile.Spec.TotalTime = reqsTime
+			}
 
 			rgAffinity := cliCtx.GlobalString("rg-affinity")
 			affinityLabels, err := kperfcmdutils.KeyValuesMap([]string{rgAffinity})

--- a/contrib/internal/manifests/loadprofile/list_configmaps.yaml
+++ b/contrib/internal/manifests/loadprofile/list_configmaps.yaml
@@ -13,15 +13,8 @@ loadProfile:
       - staleList:
           version: v1
           resource: configmaps
-        shares: 1000 # chance 1000 / (1000 + 1000 + 100)
+        shares: 100 # chance 100 / (100 + 100)
       - quorumList:
           version: v1
           resource: configmaps
-          limit: 1000
-        shares: 1000 # chance 1000 / (1000 + 1000 + 100)
-      - quorumList:
-          version: v1
-          resource: configmaps
-          limit: 1000
-          seletor: "ownerID=0"
-        shares: 100 # chance 100 / (1000 + 1000 + 100)
+        shares: 100 # chance 100 / (100 + 100)

--- a/contrib/internal/manifests/loadprofile/list_configmaps.yaml
+++ b/contrib/internal/manifests/loadprofile/list_configmaps.yaml
@@ -13,14 +13,15 @@ loadProfile:
       - staleList:
           version: v1
           resource: configmaps
-        shares: 1000 # chance 1000 / (1000 + 100 + 100)
+        shares: 1000 # chance 1000 / (1000 + 1000 + 100)
       - quorumList:
           version: v1
           resource: configmaps
           limit: 1000
-        shares: 100 # chance 100 / (1000 + 100 + 100)
+        shares: 1000 # chance 1000 / (1000 + 1000 + 100)
       - quorumList:
           version: v1
           resource: configmaps
           limit: 1000
-        shares: 100 # chance 100 / (1000 + 100 + 100)
+          seletor: "ownerID=0"
+        shares: 100 # chance 100 / (1000 + 1000 + 100)

--- a/contrib/internal/manifests/loadprofile/list_configmaps.yaml
+++ b/contrib/internal/manifests/loadprofile/list_configmaps.yaml
@@ -1,0 +1,26 @@
+count: 10
+loadProfile:
+  version: 1
+  description: "list configmaps"
+  spec:
+    rate: 10
+    conns: 10
+    client: 10
+    contentType: json
+    disableHTTP2: false
+    maxRetries: 0
+    requests:
+      - staleList:
+          version: v1
+          resource: configmaps
+        shares: 1000 # chance 1000 / (1000 + 100 + 100)
+      - quorumList:
+          version: v1
+          resource: configmaps
+          limit: 1000
+        shares: 100 # chance 100 / (1000 + 100 + 100)
+      - quorumList:
+          version: v1
+          resource: configmaps
+          limit: 1000
+        shares: 100 # chance 100 / (1000 + 100 + 100)

--- a/contrib/utils/utils.go
+++ b/contrib/utils/utils.go
@@ -482,3 +482,33 @@ func CreateTempFileWithContent(data []byte) (_name string, _cleanup func() error
 		return os.RemoveAll(fName)
 	}, nil
 }
+
+// Creates configmaps for benchmark.
+func CreateConfigmaps(ctx context.Context, kubeCfgPath string,
+	cmAmount int, cmSize int, cmGroupSize int, namespace string, timeout time.Duration) error {
+	args := []string{"data", "configmap"}
+	if kubeCfgPath != "" {
+		args = append(args, fmt.Sprintf("--kubeconfig=%s", kubeCfgPath))
+	}
+	args = append(args, fmt.Sprintf("--namespace=%s", namespace), "add", "runkperf-bench")
+	args = append(args, fmt.Sprintf("--total=%d", cmAmount))
+	args = append(args, fmt.Sprintf("--size=%d", cmSize))
+	args = append(args, fmt.Sprintf("--group-size=%d", cmGroupSize))
+
+	_, err := runCommand(ctx, timeout, "runkperf", args)
+	return err
+
+}
+
+// Delete configmaps for benchmark.
+func DeleteConfigmaps(ctx context.Context, kubeCfgPath string, namespace string, timeout time.Duration) error {
+	args := []string{"data", "configmap"}
+	if kubeCfgPath != "" {
+		args = append(args, "--kubeconfig=%s", kubeCfgPath)
+	}
+	args = append(args, fmt.Sprintf("--namespace=%s", namespace), "delete", "runkperf-bench")
+
+	_, err := runCommand(ctx, timeout, "runkperf", args)
+	return err
+
+}

--- a/request/random.go
+++ b/request/random.go
@@ -79,7 +79,10 @@ func (r *WeightedRandomRequests) Run(ctx context.Context, total int) {
 	r.wg.Add(1)
 
 	sum := 0
-	for sum < total {
+	for {
+		if total > 0 && sum >= total {
+			break
+		}
 		builder := r.randomPick()
 		select {
 		case r.reqBuilderCh <- builder:

--- a/request/random.go
+++ b/request/random.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"math/big"
 	"sync"
-	"time"
 
 	"github.com/Azure/kperf/api/types"
 
@@ -87,25 +86,6 @@ func (r *WeightedRandomRequests) Run(ctx context.Context, total int) {
 		select {
 		case r.reqBuilderCh <- builder:
 			sum++
-		case <-r.ctx.Done():
-			return
-		case <-ctx.Done():
-			return
-		}
-	}
-}
-
-// Run starts to random pick request in specific time duration.
-func (r *WeightedRandomRequests) RunForDuration(ctx context.Context, timeDuration time.Duration) {
-	end := time.Now().Add(timeDuration)
-
-	defer r.wg.Done()
-	r.wg.Add(1)
-
-	for time.Now().Before(end) {
-		builder := r.randomPick()
-		select {
-		case r.reqBuilderCh <- builder:
 		case <-r.ctx.Done():
 			return
 		case <-ctx.Done():

--- a/request/random.go
+++ b/request/random.go
@@ -93,7 +93,7 @@ func (r *WeightedRandomRequests) Run(ctx context.Context, total int) {
 }
 
 // Run starts to random pick request in specific time duration.
-func (r *WeightedRandomRequests) RunWithDuration(ctx context.Context, timeDuration time.Duration) {
+func (r *WeightedRandomRequests) RunForDuration(ctx context.Context, timeDuration time.Duration) {
 	end := time.Now().Add(timeDuration)
 
 	defer r.wg.Done()

--- a/request/schedule.go
+++ b/request/schedule.go
@@ -119,7 +119,7 @@ func Schedule(ctx context.Context, spec *types.LoadProfileSpec, restCli []rest.I
 		"connections", len(restCli),
 		"rate", qps,
 		"total", spec.Total,
-		"total-time", spec.TotalTime,
+		"duration", spec.Duration,
 		"http2", !spec.DisableHTTP2,
 		"content-type", spec.ContentType,
 	)
@@ -130,8 +130,8 @@ func Schedule(ctx context.Context, spec *types.LoadProfileSpec, restCli []rest.I
 		// If total is set, we will run for total requests.
 		// Otherwise, we will run for total time.
 		rndReqs.Run(ctx, spec.Total)
-	} else if spec.TotalTime > 0 {
-		rndReqs.RunForDuration(ctx, time.Duration(spec.TotalTime)*time.Second)
+	} else if spec.Duration > 0 {
+		rndReqs.RunForDuration(ctx, time.Duration(spec.Duration)*time.Second)
 	}
 	rndReqs.Stop()
 	wg.Wait()

--- a/request/schedule.go
+++ b/request/schedule.go
@@ -126,13 +126,14 @@ func Schedule(ctx context.Context, spec *types.LoadProfileSpec, restCli []rest.I
 
 	start := time.Now()
 
-	if spec.Total > 0 {
-		// If total is set, we will run for total requests.
-		// Otherwise, we will run for total time.
-		rndReqs.Run(ctx, spec.Total)
-	} else if spec.Duration > 0 {
-		rndReqs.RunForDuration(ctx, time.Duration(spec.Duration)*time.Second)
+	if spec.Duration > 0 {
+		// If duration is set, we will run for duration.
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(spec.Duration)*time.Second)
+		defer cancel()
 	}
+	rndReqs.Run(ctx, spec.Total)
+
 	rndReqs.Stop()
 	wg.Wait()
 

--- a/request/schedule.go
+++ b/request/schedule.go
@@ -131,7 +131,7 @@ func Schedule(ctx context.Context, spec *types.LoadProfileSpec, restCli []rest.I
 		// Otherwise, we will run for total time.
 		rndReqs.Run(ctx, spec.Total)
 	} else if spec.TotalTime > 0 {
-		rndReqs.RunWithDuration(ctx, time.Duration(spec.TotalTime)*time.Second)
+		rndReqs.RunForDuration(ctx, time.Duration(spec.TotalTime)*time.Second)
 	}
 	rndReqs.Stop()
 	wg.Wait()

--- a/request/schedule.go
+++ b/request/schedule.go
@@ -119,13 +119,20 @@ func Schedule(ctx context.Context, spec *types.LoadProfileSpec, restCli []rest.I
 		"connections", len(restCli),
 		"rate", qps,
 		"total", spec.Total,
+		"total-time", spec.TotalTime,
 		"http2", !spec.DisableHTTP2,
 		"content-type", spec.ContentType,
 	)
 
 	start := time.Now()
 
-	rndReqs.Run(ctx, spec.Total)
+	if spec.Total > 0 {
+		// If total is set, we will run for total requests.
+		// Otherwise, we will run for total time.
+		rndReqs.Run(ctx, spec.Total)
+	} else if spec.TotalTime > 0 {
+		rndReqs.RunWithDuration(ctx, time.Duration(spec.TotalTime)*time.Second)
+	}
 	rndReqs.Stop()
 	wg.Wait()
 


### PR DESCRIPTION
Add a new runkperf bench for listing configmaps:
1. Add total-time parameter to specify the duration for the runner execution;
2. Add list_configmaps benchmark command to execute benchmarks on specified resources