### PR TITLE
delete virtual nodes before node controller

### DIFF
--- a/virtualcluster/nodes_delete.go
+++ b/virtualcluster/nodes_delete.go
@@ -27,10 +27,15 @@ func DeleteNodepool(_ context.Context, kubeconfigPath string, nodepoolName strin
 		return fmt.Errorf("failed to create helm delete client: %w", err)
 	}
 
-	// delete virtual node controller first
+	err = delCli.Delete(cfg.nodeHelmReleaseName())
+	if err != nil && !errors.Is(err, driver.ErrReleaseNotFound) {
+		return fmt.Errorf("failed to cleanup virtual nodes: %w", err)
+	}
+
 	err = delCli.Delete(cfg.nodeControllerHelmReleaseName())
 	if err != nil && !errors.Is(err, driver.ErrReleaseNotFound) {
 		return fmt.Errorf("failed to cleanup virtual node controller: %w", err)
 	}
-	return delCli.Delete(cfg.nodeHelmReleaseName())
+
+	return nil
 }


### PR DESCRIPTION
This pull request modifies the `DeleteNodepool` function in `virtualcluster/nodes_delete.go` to improve error handling and cleanup logic when deleting virtual nodes and their controllers.

Improvements to error handling and cleanup:

* The deletion of virtual nodes (`cfg.nodeHelmReleaseName()`) now occurs before the deletion of the virtual node controller. This ensures proper cleanup order.
* Added error handling for the virtual node deletion step to check for `driver.ErrReleaseNotFound` and return a descriptive error if cleanup fails.
* Removed the redundant final call to delete the virtual node release, as it is now handled earlier in the function. The function now returns `nil` if all cleanup steps succeed.