### PR TITLE
cmd/kperf/commands/virtualcluster/nodepool: Add timeout flag for node…

### DIFF
--- a/cmd/kperf/commands/virtualcluster/nodepool.go
+++ b/cmd/kperf/commands/virtualcluster/nodepool.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/Azure/kperf/cmd/kperf/commands/utils"
 	"github.com/Azure/kperf/virtualcluster"
@@ -72,6 +73,11 @@ var nodepoolAddCommand = cli.Command{
 			Usage:  "Force all the virtual nodes using one provider ID",
 			Hidden: true,
 		},
+		cli.IntFlag{
+			Name:  "timeout",
+			Usage: "Timeout for creating node pool, in minutes",
+			Value: 30,
+		},
 	},
 	Action: func(cliCtx *cli.Context) error {
 		if cliCtx.NArg() != 1 {
@@ -102,6 +108,7 @@ var nodepoolAddCommand = cli.Command{
 		return virtualcluster.CreateNodepool(context.Background(),
 			kubeCfgPath,
 			nodepoolName,
+			time.Duration(cliCtx.Int("timeout"))*time.Minute,
 			virtualcluster.WithNodepoolCPUOpt(cliCtx.Int("cpu")),
 			virtualcluster.WithNodepoolMemoryOpt(cliCtx.Int("memory")),
 			virtualcluster.WithNodepoolCountOpt(cliCtx.Int("nodes")),

--- a/contrib/cmd/runkperf/commands/bench/node100_job1_pod3k.go
+++ b/contrib/cmd/runkperf/commands/bench/node100_job1_pod3k.go
@@ -57,6 +57,7 @@ func benchNode100Job1Pod3KCaseRun(cliCtx *cli.Context) (*internaltypes.Benchmark
 		cliCtx.Int("cpu"),
 		cliCtx.Int("memory"),
 		cliCtx.Int("max-pods"),
+		utils.DefaultVcTimeout,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to deploy virtual node: %w", err)

--- a/contrib/cmd/runkperf/commands/bench/node100_pod10k.go
+++ b/contrib/cmd/runkperf/commands/bench/node100_pod10k.go
@@ -77,6 +77,7 @@ func benchNode100DeploymentNPod10KRun(cliCtx *cli.Context) (*internaltypes.Bench
 		cliCtx.Int("cpu"),
 		cliCtx.Int("memory"),
 		cliCtx.Int("max-pods"),
+		utils.DefaultVcTimeout,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to deploy virtual node: %w", err)

--- a/contrib/cmd/runkperf/commands/bench/node10_job1_pod100.go
+++ b/contrib/cmd/runkperf/commands/bench/node10_job1_pod100.go
@@ -57,6 +57,7 @@ func benchNode10Job1Pod100CaseRun(cliCtx *cli.Context) (*internaltypes.Benchmark
 		cliCtx.Int("cpu"),
 		cliCtx.Int("memory"),
 		cliCtx.Int("max-pods"),
+		utils.DefaultVcTimeout,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to deploy virtual node: %w", err)

--- a/contrib/cmd/runkperf/commands/bench/utils.go
+++ b/contrib/cmd/runkperf/commands/bench/utils.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/Azure/kperf/api/types"
 	kperfcmdutils "github.com/Azure/kperf/cmd/kperf/commands/utils"
@@ -97,7 +98,7 @@ func renderBenchmarkReportInterceptor(handler subcmdActionFunc) subcmdActionFunc
 }
 
 // deployVirtualNodepool deploys virtual nodepool.
-func deployVirtualNodepool(ctx context.Context, cliCtx *cli.Context, target string, nodes, cpu, memory, maxPods int) (func() error, error) {
+func deployVirtualNodepool(ctx context.Context, cliCtx *cli.Context, target string, nodes, cpu, memory, maxPods int, vcTimeout time.Duration) (func() error, error) {
 	log.GetLogger(ctx).
 		WithKeyValues("level", "info").
 		LogKV("msg", "deploying virtual nodepool", "name", target)
@@ -127,7 +128,7 @@ func deployVirtualNodepool(ctx context.Context, cliCtx *cli.Context, target stri
 			LogKV("msg", "failed to delete nodepool", "name", target, "error", err)
 	}
 
-	err = kr.NewNodepool(ctx, 0, target, nodes, cpu, memory, maxPods, virtualNodeAffinity, sharedProviderID)
+	err = kr.NewNodepool(ctx, 0, target, nodes, cpu, memory, maxPods, virtualNodeAffinity, sharedProviderID, vcTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create nodepool %s: %w", target, err)
 	}

--- a/contrib/cmd/runkperf/commands/warmup/command.go
+++ b/contrib/cmd/runkperf/commands/warmup/command.go
@@ -220,7 +220,7 @@ func deployWarmupVirtualNodepool(ctx context.Context, kubeCfgPath string, isEKS 
 		warnLogger.LogKV("msg", "failed to delete", "nodepool", target, "error", err)
 	}
 
-	err = kr.NewNodepool(ctx, 0, target, 100, 32, 96, 110, nodeAffinity, sharedProviderID)
+	err = kr.NewNodepool(ctx, 0, target, 100, 32, 96, 110, nodeAffinity, sharedProviderID, utils.DefaultVcTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create nodepool %s: %w", target, err)
 	}

--- a/contrib/utils/kperf_cmd.go
+++ b/contrib/utils/kperf_cmd.go
@@ -22,6 +22,9 @@ func NewKperfRunner(kubeCfgPath string, runnerImage string) *KperfRunner {
 	}
 }
 
+// Default timeout for kperf to create virtual nodepool.
+const DefaultVcTimeout = 30 * time.Minute
+
 // NewNodepool creates new virtual nodepool.
 func (kr *KperfRunner) NewNodepool(
 	ctx context.Context,
@@ -29,6 +32,7 @@ func (kr *KperfRunner) NewNodepool(
 	name string, nodes int, cpu, memory, maxPods int,
 	affinity string,
 	sharedProviderID string,
+	vcTimeout time.Duration,
 ) error {
 	args := []string{"vc", "nodepool"}
 	if kr.kubeCfgPath != "" {
@@ -39,6 +43,7 @@ func (kr *KperfRunner) NewNodepool(
 		fmt.Sprintf("--cpu=%v", cpu),
 		fmt.Sprintf("--memory=%v", memory),
 		fmt.Sprintf("--max-pods=%v", maxPods),
+		fmt.Sprintf("--timeout=%v", int(vcTimeout.Minutes())),
 	)
 	if affinity != "" {
 		args = append(args, fmt.Sprintf("--affinity=%v", affinity))


### PR DESCRIPTION
Introduce a timeout flag to manage nodepool creation duration based on scale. The previous hardcoded timeout was insufficient for deploying large nodepools with thousands of virtual nodes. Benchmarks using `kperf vc nodepool` now default to a 30-minute timeout.
