### PR TITLE
runkperf/data/cm: Fix bug where ConfigMap size in randString was not correctly converted from KiB to bytes.

### DIFF
--- a/contrib/cmd/runkperf/commands/data/configmaps/configmap.go
+++ b/contrib/cmd/runkperf/commands/data/configmaps/configmap.go
@@ -299,7 +299,7 @@ func createConfigmaps(clientset *kubernetes.Clientset, namespace string, cmName 
 					"app":     appLebel,
 					"cmName":  cmName,
 				}
-				data, err := randString(size)
+				data, err := randString(size * 1024)
 				if err != nil {
 					return fmt.Errorf("failed to generate random string for configmap %s: %v", name, err)
 				}


### PR DESCRIPTION
The sizes of ConfigMaps were set via command-line flags but were not properly converted to the correct unit when generating random data.