### PR TITLE
cmd/kperf/nodepool: renamed renderRunnerGroups() to renderNodepoolList() to match functionality

### DIFF
--- a/cmd/kperf/commands/virtualcluster/nodepool.go
+++ b/cmd/kperf/commands/virtualcluster/nodepool.go
@@ -142,12 +142,12 @@ var nodepoolListCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		return renderRunnerGroups(nodepools)
+		return renderNodepoolList(nodepools)
 
 	},
 }
 
-func renderRunnerGroups(nodepools []*release.Release) error {
+func renderNodepoolList(nodepools []*release.Release) error {
 	tw := tabwriter.NewWriter(os.Stdout, 1, 12, 3, ' ', 0)
 
 	fmt.Fprintln(tw, "NAME\tNODES\tCPU\tMEMORY (GiB)\tMAX PODS\tSTATUS\t")


### PR DESCRIPTION
The kperf nodepool command uses the renderRunnerGroups() function to display the list of created nodepools, but the function name does not accurately reflect its purpose.