### PR TITLE
cmd/kperf/virtualcluster: Enable batched nodepool deployments

### DIFF
--- a/virtualcluster/nodes_common.go
+++ b/virtualcluster/nodes_common.go
@@ -50,6 +50,8 @@ const (
 type nodepoolConfig struct {
 	// name represents the name of node pool.
 	name string
+	// namespace represents the namespace of node controllers.
+	namespace string
 	// count represents the desired number of node.
 	count int
 	// cpu represents a logical CPU resource provided by virtual node.
@@ -96,6 +98,10 @@ func (cfg *nodepoolConfig) validate() error {
 
 func (cfg *nodepoolConfig) nodeHelmReleaseName() string {
 	return cfg.name
+}
+
+func (cfg *nodepoolConfig) nodeHelmReleaseNamespace() string {
+	return cfg.namespace
 }
 
 func (cfg *nodepoolConfig) nodeControllerHelmReleaseName() string {

--- a/virtualcluster/nodes_create.go
+++ b/virtualcluster/nodes_create.go
@@ -35,12 +35,15 @@ import (
 // Maybe we can consider to contribute to difference cloud providers with
 // workaround. For example, if node.Spec.ProviderID contains `?ignore=virtual`,
 // the cloud providers should ignore this kind of nodes.
-func CreateNodepool(ctx context.Context, kubeCfgPath string, nodepoolName string, opts ...NodepoolOpt) (retErr error) {
+func CreateNodepool(ctx context.Context, kubeCfgPath string, nodepoolName string, npIndex int, opts ...NodepoolOpt) (retErr error) {
 	cfg := defaultNodepoolCfg
 	for _, opt := range opts {
 		opt(&cfg)
 	}
-	cfg.name = nodepoolName
+
+	// Set nodepool name and namespace.
+	cfg.name = fmt.Sprintf("%s-%d", nodepoolName, npIndex)
+	cfg.namespace = fmt.Sprintf("%s-%s-%d", virtualnodeReleaseNamespace, nodepoolName, npIndex)
 
 	if err := cfg.validate(); err != nil {
 		return err
@@ -80,7 +83,7 @@ func CreateNodepool(ctx context.Context, kubeCfgPath string, nodepoolName string
 
 	releaseCli, err := helmcli.NewReleaseCli(
 		kubeCfgPath,
-		virtualnodeReleaseNamespace,
+		cfg.nodeHelmReleaseNamespace(),
 		cfg.nodeHelmReleaseName(),
 		ch,
 		virtualnodeReleaseLabels,
@@ -106,7 +109,7 @@ func createNodepoolController(ctx context.Context, kubeCfgPath string, cfg *node
 
 	releaseCli, err := helmcli.NewReleaseCli(
 		kubeCfgPath,
-		virtualnodeReleaseNamespace,
+		cfg.nodeHelmReleaseNamespace(),
 		cfg.nodeControllerHelmReleaseName(),
 		ch,
 		virtualnodeReleaseLabels,

--- a/virtualcluster/nodes_delete.go
+++ b/virtualcluster/nodes_delete.go
@@ -13,8 +13,8 @@ import (
 	"helm.sh/helm/v3/pkg/storage/driver"
 )
 
-// DeleteNodepool deletes a node pool with a given name.
-func DeleteNodepool(_ context.Context, kubeconfigPath string, nodepoolName string) error {
+// DeleteNodepool deletes a node pool with the given name in the specified namespace.
+func DeleteNodepool(_ context.Context, kubeconfigPath string, nodepoolName string, ns string) error {
 	cfg := defaultNodepoolCfg
 	cfg.name = nodepoolName
 
@@ -22,7 +22,7 @@ func DeleteNodepool(_ context.Context, kubeconfigPath string, nodepoolName strin
 		return err
 	}
 
-	delCli, err := helmcli.NewDeleteCli(kubeconfigPath, virtualnodeReleaseNamespace)
+	delCli, err := helmcli.NewDeleteCli(kubeconfigPath, ns)
 	if err != nil {
 		return fmt.Errorf("failed to create helm delete client: %w", err)
 	}

--- a/virtualcluster/nodes_list.go
+++ b/virtualcluster/nodes_list.go
@@ -8,31 +8,64 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Azure/kperf/contrib/utils"
 	"helm.sh/helm/v3/pkg/release"
 
 	"github.com/Azure/kperf/helmcli"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ListNodeppol lists nodepools added by the vc nodeppool add command.
-func ListNodepools(_ context.Context, kubeconfigPath string) ([]*release.Release, error) {
-	listCli, err := helmcli.NewListCli(kubeconfigPath, virtualnodeReleaseNamespace)
+func ListNodepools(_ context.Context, kubeconfigPath string, prefix string) ([]*release.Release, error) {
+	// get all namespaces with the prefix of virtualnodeReleaseNamespace
+	nsList, err := listNodepoolNamespacesWithPrefix(kubeconfigPath, prefix)
+
 	if err != nil {
-		return nil, fmt.Errorf("failed to create helm list client: %w", err)
+		return nil, fmt.Errorf("failed to list namespaces: %w", err)
 	}
 
-	releases, err := listCli.List()
-	if err != nil {
-		return nil, fmt.Errorf("failed to list nodepool: %w", err)
-	}
-
-	// NOTE: Skip node controllers
-	res := make([]*release.Release, 0, len(releases)/2)
-	for idx := range releases {
-		r := releases[idx]
-		if strings.HasSuffix(r.Name, reservedNodepoolSuffixName) {
-			continue
+	res := make([]*release.Release, 0, len(nsList))
+	for _, ns := range nsList {
+		listCli, err := helmcli.NewListCli(kubeconfigPath, ns)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create helm list client: %w", err)
 		}
-		res = append(res, r)
+
+		releases, err := listCli.List()
+		if err != nil {
+			return nil, fmt.Errorf("failed to list nodepool: %w", err)
+		}
+
+		for idx := range releases {
+			r := releases[idx]
+			if strings.HasSuffix(r.Name, reservedNodepoolSuffixName) {
+				continue
+			}
+			res = append(res, r)
+		}
+	}
+	return res, nil
+}
+
+// listNodepoolNamespacesWithPrefix lists Kperf noodpools' namespaces with a given prefix.
+func listNodepoolNamespacesWithPrefix(kubeconfigPath string, prefix string) ([]string, error) {
+	clientset, err := utils.BuildClientset(kubeconfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build clientset in listNodepoolNamespacesWithPrefix: %w", err)
+	}
+
+	nsList, err := clientset.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list namespaces in listNodepoolNamespacesWithPrefix: %w", err)
+	}
+
+	var res []string
+	// Kperf nodepools' namespaces are prefixed with virtualnodeReleaseNamespace
+	nodepoolPrefix := fmt.Sprintf("%s-%s", virtualnodeReleaseNamespace, prefix)
+	for _, ns := range nsList.Items {
+		if strings.HasPrefix(ns.Name, nodepoolPrefix) {
+			res = append(res, ns.Name)
+		}
 	}
 	return res, nil
 }


### PR DESCRIPTION
The `kperf vc nodepool` command is used to create virtual nodepools for benchmarking. However, creating a large nodepool can be inefficient.

This update introduces batch deployment: if the total number of nodes exceeds the NodesPoolThreshold, the system splits the nodepool into multiple sub-nodepools across different namespaces.  The sub-nodepools use a fixed prefix in their names and are distinguished by an auto-incremented numeric suffix.

Add a new function `listNodepoolNamespacesWithPrefix` to retrieve all namespaces with a prefix, enabling identification of all nodepools managed by Kperf. Both the `list` and `delete` commands now use this function to display or remove the relevant namespaces.