### PR TITLE
lower kwok controller cpu requests to 10m

### DIFF
--- a/manifests/virtualcluster/nodecontrollers/templates/statefulsets.tpl
+++ b/manifests/virtualcluster/nodecontrollers/templates/statefulsets.tpl
@@ -60,7 +60,7 @@ spec:
          limits:
            cpu: "500m"
          requests:
-           cpu: "200m"
+           cpu: "10m"
       restartPolicy: Always
       serviceAccount: {{ .Values.name }}
       serviceAccountName: {{ .Values.name }}


### PR DESCRIPTION
This pull request includes a small adjustment to resource requests in the `statefulsets.tpl` file. The change reduces the CPU request from `"200m"` to `"10m"` for improved resource allocation efficiency.

k top pod -n virtualnodes-kperf-io
example-4568   1m           17Mi            
example-4569   1m           13Mi            
example-457    1m           15Mi            
example-4570   1m           14Mi            
example-4571   1m           15Mi            
example-4572   1m           14Mi            
example-4573   1m           13Mi            
example-4574   1m           14Mi            
example-4575   1m           14Mi  