### PR TITLE
cmd/kperf/virtualcluster: hide lifecycle CRD and definition when listing node pools

### DIFF
--- a/virtualcluster/nodes_common.go
+++ b/virtualcluster/nodes_common.go
@@ -57,6 +57,9 @@ const (
 	//
 	// NOTE: Please check the details in ./nodes_create.go.
 	reservedNodepoolSuffixName = "-controller"
+
+	// reservedLifecyclePrefixName is the prefix of lifecycle CRD and definition.
+	reservedLifecyclePrefixName = "lifecycle-"
 )
 
 type nodepoolConfig struct {

--- a/virtualcluster/nodes_list.go
+++ b/virtualcluster/nodes_list.go
@@ -29,7 +29,7 @@ func ListNodepools(_ context.Context, kubeconfigPath string) ([]*release.Release
 	res := make([]*release.Release, 0, len(releases)/2)
 	for idx := range releases {
 		r := releases[idx]
-		if strings.HasSuffix(r.Name, reservedNodepoolSuffixName) {
+		if strings.HasSuffix(r.Name, reservedNodepoolSuffixName) || strings.HasPrefix(r.Name, reservedLifecyclePrefixName) {
 			continue
 		}
 		res = append(res, r)


### PR DESCRIPTION
Since the lifecycle CRD and definition have been installed in **virtualnodeReleaseNamespace** namespace, it will show up when listing node pools. 
```shell
NAME            NODES       CPU     MEMORY (GiB)   MAX PODS   STATUS
lifecycle-crd   ? / <nil>   <nil>   <nil>          <nil>      deployed
lifecycle-def   ? / <nil>   <nil>   <nil>          <nil>      deployed
``` 
These should be ignored, as they are not actual virtual node pools.