### PR TITLE
feat: Add batch-add command to split large node pool into smaller one…

### DIFF
--- a/cmd/kperf/commands/virtualcluster/nodepool.go
+++ b/cmd/kperf/commands/virtualcluster/nodepool.go
@@ -170,7 +170,7 @@ var nodepoolBatchAddCommand = cli.Command{
 		}
 		nodepoolName := strings.TrimSpace(cliCtx.Args().Get(0))
 		if len(nodepoolName) == 0 {
-			return fmt.Errorf("nodepool name cannot be empty")
+			return fmt.Errorf("nodepool name prefix should not be empty")
 		}
 
 		kubeCfgPath := cliCtx.GlobalString("kubeconfig")

--- a/cmd/kperf/commands/virtualcluster/nodepool.go
+++ b/cmd/kperf/commands/virtualcluster/nodepool.go
@@ -201,7 +201,7 @@ var nodepoolBatchAddCommand = cli.Command{
 				currentBatchSize = totalNodes - i
 			}
 
-			batchNodepoolName := fmt.Sprintf("%s-batch-%d", nodepoolName, i/batchSize)
+			batchNodepoolName := fmt.Sprintf("%s-%d", nodepoolName, i/batchSize)
 			if err := virtualcluster.CreateNodepool(context.Background(),
 				kubeCfgPath,
 				batchNodepoolName,

--- a/cmd/kperf/commands/virtualcluster/nodepool.go
+++ b/cmd/kperf/commands/virtualcluster/nodepool.go
@@ -36,6 +36,9 @@ var nodepoolCommand = cli.Command{
 	},
 }
 
+// maxNodesPerPool is the maximum number of nodes suggested for a single node pool.
+const maxNodesPerPool = 300
+
 var nodepoolAddCommand = cli.Command{
 	Name:      "add",
 	Usage:     "Add a virtual node pool",
@@ -102,7 +105,7 @@ var nodepoolAddCommand = cli.Command{
 		}
 
 		nodes := cliCtx.Int("nodes")
-		if nodes > 300 {
+		if nodes > maxNodesPerPool {
 			klog.Warningf("Creating a node pool with a large number of nodes may cause performance issues. Consider using batch-add command for large node pools.")
 		}
 

--- a/cmd/kperf/commands/virtualcluster/nodepool.go
+++ b/cmd/kperf/commands/virtualcluster/nodepool.go
@@ -15,6 +15,7 @@ import (
 	"helm.sh/helm/v3/pkg/release"
 
 	"github.com/urfave/cli"
+	"k8s.io/klog/v2"
 )
 
 var nodepoolCommand = cli.Command{
@@ -29,6 +30,7 @@ var nodepoolCommand = cli.Command{
 	},
 	Subcommands: []cli.Command{
 		nodepoolAddCommand,
+		nodepoolBatchAddCommand,
 		nodepoolDelCommand,
 		nodepoolListCommand,
 	},
@@ -99,17 +101,124 @@ var nodepoolAddCommand = cli.Command{
 			return fmt.Errorf("failed to parse node-labels: %w", err)
 		}
 
+		nodes := cliCtx.Int("nodes")
+		if nodes > 300 {
+			klog.Warningf("Creating a node pool with a large number of nodes may cause performance issues. Consider using batch-add command for large node pools.")
+		}
+
 		return virtualcluster.CreateNodepool(context.Background(),
 			kubeCfgPath,
 			nodepoolName,
 			virtualcluster.WithNodepoolCPUOpt(cliCtx.Int("cpu")),
 			virtualcluster.WithNodepoolMemoryOpt(cliCtx.Int("memory")),
-			virtualcluster.WithNodepoolCountOpt(cliCtx.Int("nodes")),
+			virtualcluster.WithNodepoolCountOpt(nodes),
 			virtualcluster.WithNodepoolMaxPodsOpt(cliCtx.Int("max-pods")),
 			virtualcluster.WithNodepoolNodeControllerAffinity(affinityLabels),
 			virtualcluster.WithNodepoolLabelsOpt(nodeLabels),
 			virtualcluster.WithNodepoolSharedProviderID(cliCtx.String("shared-provider-id")),
 		)
+	},
+}
+
+var nodepoolBatchAddCommand = cli.Command{
+	Name:      "batch-add",
+	Usage:     "Add nodes in batch to multiple virtual node pools instead of one node pool with a large number of nodes",
+	ArgsUsage: "NAME",
+	Flags: []cli.Flag{
+		cli.IntFlag{
+			Name:  "nodes",
+			Usage: "The number of virtual nodes",
+			Value: 10,
+		},
+		cli.IntFlag{
+			Name:  "cpu",
+			Usage: "The allocatable CPU resource per node",
+			Value: 8,
+		},
+		cli.IntFlag{
+			Name:  "memory",
+			Usage: "The allocatable Memory resource per node (GiB)",
+			Value: 16,
+		},
+		cli.IntFlag{
+			Name:  "max-pods",
+			Usage: "The maximum Pods per node",
+			Value: 110,
+		},
+		cli.StringSliceFlag{
+			Name:  "affinity",
+			Usage: "Deploy controllers to the nodes with a specific labels (FORMAT: KEY=VALUE[,VALUE])",
+		},
+		cli.StringSliceFlag{
+			Name:  "node-labels",
+			Usage: "Additional labels to node (FORMAT: KEY=VALUE)",
+		},
+		cli.StringFlag{
+			Name:   "shared-provider-id",
+			Usage:  "Force all the virtual nodes using one provider ID",
+			Hidden: true,
+		},
+		cli.IntFlag{
+			Name:  "batch-size",
+			Usage: "Maximum number of nodes to create in one batch, default is 300",
+			Value: 300,
+		},
+	},
+	Action: func(cliCtx *cli.Context) error {
+		if cliCtx.NArg() != 1 {
+			return fmt.Errorf("expected exactly one argument as nodepool name: %v", cliCtx.Args())
+		}
+		nodepoolName := strings.TrimSpace(cliCtx.Args().Get(0))
+		if len(nodepoolName) == 0 {
+			return fmt.Errorf("nodepool name cannot be empty")
+		}
+
+		kubeCfgPath := cliCtx.GlobalString("kubeconfig")
+
+		if err := utils.ApplyPriorityLevelConfiguration(kubeCfgPath); err != nil {
+			return fmt.Errorf("failed to apply priority level configuration: %w", err)
+		}
+
+		affinityLabels, err := utils.KeyValuesMap(cliCtx.StringSlice("affinity"))
+		if err != nil {
+			return fmt.Errorf("failed to parse affinity labels: %w", err)
+		}
+
+		nodeLabels, err := utils.KeyValueMap(cliCtx.StringSlice("node-labels"))
+		if err != nil {
+			return fmt.Errorf("failed to parse node labels: %w", err)
+		}
+
+		totalNodes := cliCtx.Int("nodes")
+		batchSize := cliCtx.Int("batch-size")
+		if batchSize <= 0 {
+			return fmt.Errorf("batch-size must be greater than zero")
+		}
+
+		for i := 0; i < totalNodes; i += batchSize {
+			currentBatchSize := batchSize
+			if i+currentBatchSize > totalNodes {
+				currentBatchSize = totalNodes - i
+			}
+
+			batchNodepoolName := fmt.Sprintf("%s-batch-%d", nodepoolName, i/batchSize)
+			if err := virtualcluster.CreateNodepool(context.Background(),
+				kubeCfgPath,
+				batchNodepoolName,
+				virtualcluster.WithNodepoolCPUOpt(cliCtx.Int("cpu")),
+				virtualcluster.WithNodepoolMemoryOpt(cliCtx.Int("memory")),
+				virtualcluster.WithNodepoolCountOpt(currentBatchSize),
+				virtualcluster.WithNodepoolMaxPodsOpt(cliCtx.Int("max-pods")),
+				virtualcluster.WithNodepoolNodeControllerAffinity(affinityLabels),
+				virtualcluster.WithNodepoolLabelsOpt(nodeLabels),
+				virtualcluster.WithNodepoolSharedProviderID(cliCtx.String("shared-provider-id")),
+			); err != nil {
+				return fmt.Errorf("failed to create nodepool batch %s: %w", batchNodepoolName, err)
+			}
+			klog.Infof("Created nodepool batch %s with %d nodes", batchNodepoolName, currentBatchSize)
+		}
+
+		return nil
 	},
 }
 

--- a/cmd/kperf/commands/virtualcluster/nodepool.go
+++ b/cmd/kperf/commands/virtualcluster/nodepool.go
@@ -166,7 +166,7 @@ var nodepoolBatchAddCommand = cli.Command{
 	},
 	Action: func(cliCtx *cli.Context) error {
 		if cliCtx.NArg() != 1 {
-			return fmt.Errorf("expected exactly one argument as nodepool name: %v", cliCtx.Args())
+			return fmt.Errorf("expected exactly one argument as name prefix for nodepool: %v", cliCtx.Args())
 		}
 		nodepoolName := strings.TrimSpace(cliCtx.Args().Get(0))
 		if len(nodepoolName) == 0 {

--- a/virtualcluster/nodes_common.go
+++ b/virtualcluster/nodes_common.go
@@ -57,6 +57,9 @@ const (
 	//
 	// NOTE: Please check the details in ./nodes_create.go.
 	reservedNodepoolSuffixName = "-controller"
+
+	// reservedLifecyclePrefixName is the prefix of lifecycle CRD and definition.
+	reservedLifecyclePrefixName = "lifecycle-"
 )
 
 type nodepoolConfig struct {

--- a/virtualcluster/nodes_list.go
+++ b/virtualcluster/nodes_list.go
@@ -29,7 +29,7 @@ func ListNodepools(_ context.Context, kubeconfigPath string) ([]*release.Release
 	res := make([]*release.Release, 0, len(releases)/2)
 	for idx := range releases {
 		r := releases[idx]
-		if strings.HasSuffix(r.Name, reservedNodepoolSuffixName) {
+		if strings.HasSuffix(r.Name, reservedNodepoolSuffixName) || strings.HasPrefix(r.Name, reservedLifecyclePrefixName) {
 			continue
 		}
 		res = append(res, r)


### PR DESCRIPTION
…s for batched deployment

This update introduces a new command that enables splitting a large node pool into smaller ones, helping to prevent issues like oversized manifests and timeouts.