### PR TITLE
runkperf/node10_job1_pod100: Only deploy 10 virtual nodes in node10_job1_pod100 benchmarking

### DIFF
--- a/contrib/cmd/runkperf/commands/bench/node10_job1_pod100.go
+++ b/contrib/cmd/runkperf/commands/bench/node10_job1_pod100.go
@@ -53,7 +53,7 @@ func benchNode10Job1Pod100CaseRun(cliCtx *cli.Context) (*internaltypes.Benchmark
 	defer func() { _ = rgCfgFileDone() }()
 
 	vcDone, err := deployVirtualNodepool(ctx, cliCtx, "node10job1pod100",
-		100,
+		10,
 		cliCtx.Int("cpu"),
 		cliCtx.Int("memory"),
 		cliCtx.Int("max-pods"),


### PR DESCRIPTION
The node10_job1_pod100 benchmark is intended to run with 10 virtual nodes.