### PR TITLE
Clean up runner group namespace after deletion

### DIFF
--- a/runner/runnergroup_delete.go
+++ b/runner/runnergroup_delete.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Azure/kperf/contrib/utils"
 	"github.com/Azure/kperf/helmcli"
 )
 
@@ -17,5 +18,16 @@ func DeleteRunnerGroupServer(_ context.Context, kubeconfigPath string) error {
 		return fmt.Errorf("failed to create helm delete client: %w", err)
 	}
 
-	return delCli.Delete(runnerGroupServerReleaseName)
+	err = delCli.Delete(runnerGroupServerReleaseName)
+	if err != nil {
+		return fmt.Errorf("failed to delete runner group server: %w", err)
+	}
+
+	// Delete the namespace after deleting the release.
+	kr := utils.NewKubectlRunner(kubeconfigPath, runnerGroupReleaseNamespace)
+	err = kr.DeleteNamespace(context.Background(), 0, runnerGroupReleaseNamespace)
+	if err != nil {
+		return fmt.Errorf("failed to delete runner group namespace %s: %w", runnerGroupReleaseNamespace, err)
+	}
+	return nil
 }


### PR DESCRIPTION
Remove the runnerGroupReleaseNamespace namespace, which has been created by Helm.