### PR TITLE
Bug fix: GET operation does not include namespace

### DIFF
--- a/request/random.go
+++ b/request/random.go
@@ -167,6 +167,9 @@ func (b *requestGetBuilder) Build(cli rest.Interface) Requester {
 	} else {
 		comps = append(comps, "apis", b.version.Group, b.version.Version)
 	}
+	if b.namespace != "" {
+		comps = append(comps, "namespaces", b.namespace)
+	}
 	comps = append(comps, b.resource, b.name)
 
 	return &DiscardRequester{


### PR DESCRIPTION

**Fix: 404 Error When Namespace Is Specified in GET Request**

Previously, a GET request for a namespaced resource returned a 404 error, even when the resource name was valid:

```json
{
  "url": "https://10.0.0.1:443/api/v1/pods/node10job1pod1k-1?resourceVersion=0&timeout=1m0s",
  "timestamp": "2025-07-09T04:33:54.232768244Z",
  "duration": 0.002615457,
  "type": "http",
  "code": 404,
  "message": ""
}
```

This occurred because the namespace was not properly included in the request path. According to the Kubernetes API specification, the correct format for retrieving a resource by name **within a namespace** should be:

```
/api/v1/namespaces/{namespace}/pods/{name}
```

![Expected Format](https://github.com/user-attachments/assets/ac378ffe-6dd0-4d11-b731-c04827ec2ed2)

Root Cause

The namespace segment was missing in the GET request path construction logic, which led to incorrect targeting and ultimately a 404.

Solution

This PR corrects the GET request path by appending the namespace when specified. After applying this fix, the request behaves as expected:

![Fixed Result](https://github.com/user-attachments/assets/64987775-8396-4671-a07a-a66dfd3b11f4)

This change aligns the implementation with Kubernetes API standards.


Thanks to @xinWeiWei24 for helping me navigating this issue 
