### PR TITLE
node100_pod10k: avoid redundant dpcancel call—defer already set

### DIFF
--- a/contrib/cmd/runkperf/commands/bench/node100_pod10k.go
+++ b/contrib/cmd/runkperf/commands/bench/node100_pod10k.go
@@ -106,7 +106,6 @@ func benchNode100DeploymentNPod10KRun(cliCtx *cli.Context) (*internaltypes.Bench
 	ruCleanupFn, err := utils.DeployDeployments(dpCtx,
 		kubeCfgPath, deploymentNamePattern, total, replica, paddingBytes)
 	if err != nil {
-		dpCancel()
 		return nil, fmt.Errorf("failed to setup workload: %w", err)
 	}
 	defer ruCleanupFn()


### PR DESCRIPTION
dpCancel() was already deferred earlier, so there's no need to call it again.