### PR TITLE
Improve patch type to randomized resource name

### DIFF
--- a/api/types/load_traffic.go
+++ b/api/types/load_traffic.go
@@ -159,7 +159,7 @@ type RequestPatch struct {
 	KubeGroupVersionResource `yaml:",inline"`
 	// Namespace is object's namespace.
 	Namespace string `json:"namespace" yaml:"namespace"`
-	// Name is object's name Pattern e.g keprf-{suffix index}.
+	// Name is object's name Pattern e.g kperf-{suffix index}.
 	Name string `json:"name" yaml:"name"`
 	// KeySpaceSize is used to generate random number as name's suffix.
 	KeySpaceSize int `json:"keySpaceSize" yaml:"keySpaceSize"`

--- a/api/types/load_traffic.go
+++ b/api/types/load_traffic.go
@@ -159,8 +159,10 @@ type RequestPatch struct {
 	KubeGroupVersionResource `yaml:",inline"`
 	// Namespace is object's namespace.
 	Namespace string `json:"namespace" yaml:"namespace"`
-	// Name is object's prefix name.
+	// Name is object's name Pattern e.g keprf-{suffix index}.
 	Name string `json:"name" yaml:"name"`
+	// KeySpaceSize is used to generate random number as name's suffix.
+	KeySpaceSize int `json:"keySpaceSize" yaml:"keySpaceSize"`
 	// PatchType is the type of patch, e.g. "json", "merge", "strategic-merge".
 	PatchType string `json:"patchType" yaml:"patchType"`
 	// Body is the request body, for fields to be changed.

--- a/docs/kperf.md
+++ b/docs/kperf.md
@@ -7,7 +7,7 @@ This document provides instructions for testing and using kperf to benchmark Kub
 ### kperf runner run
 
 The `kperf runner run` command generates requests from the endpoint where the command is executed. All requests are generated based on a load profile configuration.
-
+p
 Example load profile (`/tmp/example-loadprofile.yaml`):
 
 ```yaml
@@ -45,7 +45,7 @@ spec:
         version: v1
         resource: pods
         limit: 1000
-      shares: 1000 # Has 50% chance = 1000 / (1000 + 1000)
+      shares: 1000 # Has 50% chance vim= 1000 / (1000 + 1000)
 ```
 
 This profile generates two types of requests:

--- a/docs/kperf.md
+++ b/docs/kperf.md
@@ -7,7 +7,6 @@ This document provides instructions for testing and using kperf to benchmark Kub
 ### kperf runner run
 
 The `kperf runner run` command generates requests from the endpoint where the command is executed. All requests are generated based on a load profile configuration.
-p
 Example load profile (`/tmp/example-loadprofile.yaml`):
 
 ```yaml
@@ -45,7 +44,7 @@ spec:
         version: v1
         resource: pods
         limit: 1000
-      shares: 1000 # Has 50% chance vim= 1000 / (1000 + 1000)
+      shares: 1000 # Has 50% chance = 1000 / (1000 + 1000)
 ```
 
 This profile generates two types of requests:

--- a/request/random.go
+++ b/request/random.go
@@ -363,6 +363,7 @@ type requestPatchBuilder struct {
 	resourceVersion string
 	namespace       string
 	name            string
+	keySpaceSize    int
 	patchType       apitypes.PatchType
 	body            interface{}
 	maxRetries      int
@@ -380,6 +381,7 @@ func newRequestPatchBuilder(src *types.RequestPatch, resourceVersion string, max
 		resourceVersion: resourceVersion,
 		namespace:       src.Namespace,
 		name:            src.Name,
+		keySpaceSize:    src.KeySpaceSize,
 		patchType:       patchType,
 		body:            []byte(src.Body),
 		maxRetries:      maxRetries,
@@ -398,7 +400,13 @@ func (b *requestPatchBuilder) Build(cli rest.Interface) Requester {
 	if b.namespace != "" {
 		comps = append(comps, "namespaces", b.namespace)
 	}
-	comps = append(comps, b.resource, b.name)
+	// Generate random suffix based on keySpaceSize
+    randomInt, _ := rand.Int(rand.Reader, big.NewInt(int64(b.keySpaceSize)))
+    suffix := randomInt.Int64()
+    
+    // Create final resource name: name-{suffix}
+    finalName := fmt.Sprintf("%s-%d", b.name, suffix)
+	comps = append(comps, b.resource, finalName)
 
 	return &DiscardRequester{
 		BaseRequester: BaseRequester{


### PR DESCRIPTION
This PR improves the patch operation by supporting dynamic resource names through a randomized suffix. Users can specify a name pattern (e.g., benchmark-{suffix}), and a random number will be generated as the suffix based on the defined keySpaceSize.

# Example Usage
```
  - patch:
      version: v1
      resource: configmaps
      namespace: default
      patchType: merge
      name: benchmark # name pattern
      keySpaceSize: 100 # randomize suffix
      body: |
        {
          "metadata": {
            "labels": {
              "test-label": "mutation-test"
            }
          }
        }
    shares: 100
```