### PR TITLE
Add --ignore-not-found flag to namespace deletion

### DIFF
--- a/contrib/utils/kubectl_cmd.go
+++ b/contrib/utils/kubectl_cmd.go
@@ -98,7 +98,7 @@ func (kr *KubectlRunner) DeleteNamespace(ctx context.Context, timeout time.Durat
 	if kr.kubeCfgPath != "" {
 		args = append(args, "--kubeconfig", kr.kubeCfgPath)
 	}
-	args = append(args, "delete", "namespace", name)
+	args = append(args, "delete", "namespace", name, "--ignore-not-found=true")
 
 	_, err := runCommand(ctx, timeout, "kubectl", args)
 	return err


### PR DESCRIPTION
Make DeleteNamespace idempotent by adding --ignore-not-found=true flag. This prevents errors when deleting non-existent namespaces, like this:

> I0806 15:29:35.767611 1167408 klogger.go:28] "" level="info" msg="stop creating job"
I0806 15:29:35.767642 1167408 klogger.go:28] "" level="info" msg="cleanup namespace" name="job1pod100"
I0806 15:29:35.767703 1167408 klogger.go:28] "" level="info" msg="start command" cmd="/usr/local/bin/kubectl --kubeconfig /home/zhilan/aks-rp2/kubeconfig_kperf.yaml delete namespace job1pod100"
I0806 15:29:41.596080 1167408 klogger.go:28] "" level="info" msg="start command" cmd="/usr/local/bin/kperf vc nodepool --kubeconfig=/home/zhilan/aks-rp2/kubeconfig_kperf.yaml delete node10job1pod100"
runkperf: failed to delete existing runner group: failed to invoke /usr/local/bin/kperf rg --kubeconfig=/home/zhilan/aks-rp2/kubeconfig_kperf.yaml delete:
 (output: kperf: failed to delete runner group namespace runnergroups-kperf-io: failed to invoke /usr/local/bin/kubectl --kubeconfig /home/zhilan/aks-rp2/kubeconfig_kperf.yaml delete namespace runnergroups-kperf-io:
 (output: Error from server (NotFound): namespaces "runnergroups-kperf-io" not found): exit status 1): exit status 1