### PR TITLE
Fix YAML/JSON field name consistency for LoadProfileSpec.Requests

### DIFF
--- a/api/types/load_traffic.go
+++ b/api/types/load_traffic.go
@@ -63,7 +63,7 @@ type LoadProfileSpec struct {
 	MaxRetries int `json:"maxRetries" yaml:"maxRetries"`
 	// Requests defines the different kinds of requests with weights.
 	// The executor should randomly pick by weight.
-	Requests []*WeightedRequest
+	Requests []*WeightedRequest `json:"requests" yaml:"requests"`
 }
 
 // KubeGroupVersionResource identifies the resource URI.


### PR DESCRIPTION
Add explicit json and yaml tags to ensure "requests" field name is preserved during marshaling/unmarshaling instead of defaulting to "Requests".

We now use sigs.k8s.io/yaml, which strictly validates each field. The data is marshaled into the "Requests", but it will not be unmarshaled back into "requests".
<img width="800" height="452" alt="image" src="https://github.com/user-attachments/assets/53b2bc14-332f-43ba-82ca-709d0e2564d7" />
