### PR TITLE
Add namePattern parameter to CreateConfigmaps func

### DIFF
--- a/contrib/cmd/runkperf/commands/bench/list_configmaps.go
+++ b/contrib/cmd/runkperf/commands/bench/list_configmaps.go
@@ -74,7 +74,7 @@ func benchListConfigmapsRun(cliCtx *cli.Context) (*internaltypes.BenchmarkReport
 	cmSize := cliCtx.Int("size")
 	cmGroupSize := cliCtx.Int("group-size")
 
-	err = utils.CreateConfigmaps(ctx, kubeCfgPath, cmAmount, cmSize, cmGroupSize, benchConfigmapNamespace, 0)
+	err = utils.CreateConfigmaps(ctx, kubeCfgPath, benchConfigmapNamespace, "runkperf-bench", cmAmount, cmSize, cmGroupSize, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/contrib/cmd/runkperf/commands/bench/list_configmaps.go
+++ b/contrib/cmd/runkperf/commands/bench/list_configmaps.go
@@ -81,7 +81,7 @@ func benchListConfigmapsRun(cliCtx *cli.Context) (*internaltypes.BenchmarkReport
 
 	defer func() {
 		// Delete the configmaps after the benchmark
-		err = utils.DeleteConfigmaps(ctx, kubeCfgPath, benchConfigmapNamespace, 0)
+		err = utils.DeleteConfigmaps(ctx, kubeCfgPath, benchConfigmapNamespace, "runkperf-bench", 0)
 		if err != nil {
 			log.GetLogger(ctx).WithKeyValues("level", "error").
 				LogKV("msg", fmt.Sprintf("Failed to delete configmaps: %v", err))

--- a/contrib/utils/utils.go
+++ b/contrib/utils/utils.go
@@ -550,9 +550,7 @@ func CreateConfigmaps(ctx context.Context, kubeCfgPath, namespace, namePattern s
 	if kubeCfgPath != "" {
 		args = append(args, fmt.Sprintf("--kubeconfig=%s", kubeCfgPath))
 	}
-	if namePattern == "" {
-		namePattern = "runkperf-bench"
-	}
+
 	args = append(args, fmt.Sprintf("--namespace=%s", namespace), "add", namePattern)
 	args = append(args, fmt.Sprintf("--total=%d", cmAmount))
 	args = append(args, fmt.Sprintf("--size=%d", cmSize))

--- a/contrib/utils/utils.go
+++ b/contrib/utils/utils.go
@@ -544,13 +544,16 @@ func CreateTempFileWithContent(data []byte) (_name string, _cleanup func() error
 }
 
 // Creates configmaps for benchmark.
-func CreateConfigmaps(ctx context.Context, kubeCfgPath string,
-	cmAmount int, cmSize int, cmGroupSize int, namespace string, timeout time.Duration) error {
+func CreateConfigmaps(ctx context.Context, kubeCfgPath, namespace, namePattern string,
+	cmAmount, cmSize, cmGroupSize int, timeout time.Duration) error {
 	args := []string{"data", "configmap"}
 	if kubeCfgPath != "" {
 		args = append(args, fmt.Sprintf("--kubeconfig=%s", kubeCfgPath))
 	}
-	args = append(args, fmt.Sprintf("--namespace=%s", namespace), "add", "runkperf-bench")
+	if namePattern == "" {
+		namePattern = "runkperf-bench"
+	}
+	args = append(args, fmt.Sprintf("--namespace=%s", namespace), "add", namePattern)
 	args = append(args, fmt.Sprintf("--total=%d", cmAmount))
 	args = append(args, fmt.Sprintf("--size=%d", cmSize))
 	args = append(args, fmt.Sprintf("--group-size=%d", cmGroupSize))

--- a/contrib/utils/utils.go
+++ b/contrib/utils/utils.go
@@ -564,12 +564,12 @@ func CreateConfigmaps(ctx context.Context, kubeCfgPath, namespace, namePattern s
 }
 
 // Delete configmaps for benchmark.
-func DeleteConfigmaps(ctx context.Context, kubeCfgPath string, namespace string, timeout time.Duration) error {
+func DeleteConfigmaps(ctx context.Context, kubeCfgPath, namespace, namePattern string, timeout time.Duration) error {
 	args := []string{"data", "configmap"}
 	if kubeCfgPath != "" {
-		args = append(args, "--kubeconfig=%s", kubeCfgPath)
+		args = append(args, fmt.Sprintf("--kubeconfig=%s", kubeCfgPath))
 	}
-	args = append(args, fmt.Sprintf("--namespace=%s", namespace), "delete", "runkperf-bench")
+	args = append(args, fmt.Sprintf("--namespace=%s", namespace), "delete", namePattern)
 
 	_, err := runCommand(ctx, timeout, "runkperf", args)
 	return err


### PR DESCRIPTION
Allow customizing ConfigMap naming pattern instead of using fixed "runkperf-bench" default. Falls back to default if empty string provided.