### PR TITLE
fix: base64-encode runnerGroupSpec to prevent errors in helm.StringPathValuesApplier

### DIFF
--- a/manifests/runnergroup/server/templates/spec.yaml
+++ b/manifests/runnergroup/server/templates/spec.yaml
@@ -6,4 +6,4 @@ metadata:
   name: {{ .Values.name }}-init-spec
   namespace: {{ .Release.Namespace }}
 data:
-  spec: {{ .Values.runnerGroupSpec | toYaml | indent 2 }}
+  spec: {{ .Values.runnerGroupSpec | b64dec | toYaml | indent 2 }}

--- a/runner/runnergroup_run.go
+++ b/runner/runnergroup_run.go
@@ -5,6 +5,7 @@ package runner
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"time"
 
@@ -68,6 +69,7 @@ func CreateRunnerGroupServer(ctx context.Context,
 	if err != nil {
 		return fmt.Errorf("failed to load runner group server chart: %w", err)
 	}
+	encoded := base64.StdEncoding.EncodeToString([]byte(specInStr))
 
 	releaseCli, err := helmcli.NewReleaseCli(
 		kubeconfigPath,
@@ -78,7 +80,7 @@ func CreateRunnerGroupServer(ctx context.Context,
 		helmcli.StringPathValuesApplier(
 			"name="+runnerGroupServerReleaseName,
 			"image="+runnerImage,
-			"runnerGroupSpec="+specInStr,
+			"runnerGroupSpec="+encoded,
 			// runnerVerbosity needs to be surrounded by quotes, so that YAML parse it as a string.
 			fmt.Sprintf("runnerVerbosity=\"%d\"", runnerVerbosity),
 		),


### PR DESCRIPTION
When invoking helm.StringPathValuesApplier during a PATCH operation, passing runnerGroupSpec as a raw string fails if the body contains special characters "[" or "]", like this:
```
- patch:
    version: v1
    resource: pods
    namespace: kperf
    patchType: json
    name: test-pod4
    body: |
      [
        {
          "op": "replace",
          "path": "/metadata/labels",
          "value": {}
        }
      ]
  shares: 100
```

To resolve this:
- runnerGroupSpec is now base64-encoded before being passed to Helm
- Decoded in the Helm template using `b64dec` before applying `toYaml`