### PR TITLE
Simplify PATCH request configuration

### DIFF
--- a/contrib/internal/manifests/loadprofile/read_update.yaml
+++ b/contrib/internal/manifests/loadprofile/read_update.yaml
@@ -20,15 +20,6 @@ loadProfile:
           version: v1
           resource: configmaps
           namespace: default
-          patchType: merge
           name: runkperf-cm-kperf-read-update
           keySpaceSize: 100
-          body: |
-            {
-              "metadata": {
-                "labels": {
-                  "test-label": "mutation-test"
-                }
-              }
-            }
         shares: 50


### PR DESCRIPTION
Removed body and type methods from PATCH operations for easier setup. Replaced annotations with timestamps to ensure updates are triggered consistently.