### PR TITLE
fix: apply node affinity to runner pods

### DIFF
--- a/cmd/kperf/commands/runnergroup/run.go
+++ b/cmd/kperf/commands/runnergroup/run.go
@@ -44,7 +44,7 @@ var runCommand = cli.Command{
 		},
 		cli.StringSliceFlag{
 			Name:  "affinity",
-			Usage: "Deploy server to the node with a specific labels (FORMAT: KEY=VALUE[,VALUE])",
+			Usage: "Deploy server and runners to the node with a specific labels (FORMAT: KEY=VALUE[,VALUE])",
 		},
 		cli.IntFlag{
 			Name:  "runner-verbosity",
@@ -75,6 +75,8 @@ var runCommand = cli.Command{
 		if len(specs) != 1 {
 			return fmt.Errorf("only support one runner group right now. will support it after https://github.com/Azure/kperf/issues/25")
 		}
+
+		specs[0].NodeAffinity = affinityLabels
 
 		kubeCfgPath := cliCtx.GlobalString("kubeconfig")
 		return runner.CreateRunnerGroupServer(context.Background(),

--- a/runner/group/handler.go
+++ b/runner/group/handler.go
@@ -374,6 +374,11 @@ func (h *Handler) buildBatchJobObject(uploadURL string) *batchv1.Job {
 		job.OwnerReferences = append(job.OwnerReferences, *h.ownerRef)
 	}
 
+	job.Spec.Template.ObjectMeta = metav1.ObjectMeta{
+		Labels: map[string]string{
+			"app-name-job": h.name,
+		},
+	}
 	job.Spec.Template.Spec = corev1.PodSpec{
 		Affinity: &corev1.Affinity{},
 		Containers: []corev1.Container{
@@ -430,6 +435,19 @@ func (h *Handler) buildBatchJobObject(uploadURL string) *batchv1.Job {
 			},
 		},
 		RestartPolicy: corev1.RestartPolicyNever,
+		TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+			{
+				MaxSkew:           1,
+				TopologyKey:       "kubernetes.io/hostname",
+				WhenUnsatisfiable: corev1.ScheduleAnyway,
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app-name-job": h.name,
+					},
+				},
+			},
+		},
+
 		Volumes: []corev1.Volume{
 			{
 				Name: "config",


### PR DESCRIPTION
…raints

This ensures runner pods are both scheduled on the correct node types and distributed evenly across available nodes for optimal performance testing.