### PR TITLE
feat(request): substitute {{.Random}} patch token with a random string

### DIFF
--- a/api/types/load_traffic.go
+++ b/api/types/load_traffic.go
@@ -170,6 +170,13 @@ type RequestPatch struct {
 	// PatchType is the type of patch, e.g. "json", "merge", "strategic-merge".
 	PatchType string `json:"patchType" yaml:"patchType"`
 	// Body is the request body, for fields to be changed.
+	//
+	// The literal token "{{.Random}}" in Body is replaced on every request with
+	// a random string. Use it to guarantee each patch mutates the target object:
+	// re-applying identical data is a no-op that bumps no resourceVersion and
+	// emits no watch event, so a static body's event rate decays as objects
+	// converge. A Body without the token is sent unchanged.
+	// e.g. '{"metadata":{"labels":{"bench-tick":"{{.Random}}"}}}'.
 	Body string `json:"body" yaml:"body"`
 }
 

--- a/request/random.go
+++ b/request/random.go
@@ -366,11 +366,9 @@ func (b *requestGetPodLogBuilder) Build(cli rest.Interface) Requester {
 	}
 }
 
-// patchRandomPlaceholder is a token that, when present in a patch body, is
+// When this placeholder is present in a patch body, it is
 // replaced on every request with a random string. This guarantees each patch
-// actually mutates the target object instead of re-applying identical data
-// (which the apiserver treats as a no-op that bumps no resourceVersion and
-// emits no watch event).
+// actually mutates the target object.
 const patchRandomPlaceholder = "{{.Random}}"
 
 type requestPatchBuilder struct {
@@ -386,8 +384,7 @@ type requestPatchBuilder struct {
 }
 
 // renderPatchBody replaces every occurrence of patchRandomPlaceholder in raw
-// with a random string. A body without the placeholder is returned unchanged
-// (backward compatible with existing profiles).
+// with a random string.
 func renderPatchBody(raw string) []byte {
 	if !strings.Contains(raw, patchRandomPlaceholder) {
 		return []byte(raw)

--- a/request/random.go
+++ b/request/random.go
@@ -379,7 +379,7 @@ type requestPatchBuilder struct {
 	name            string
 	keySpaceSize    int
 	patchType       apitypes.PatchType
-	rawBody         string
+	body            string
 	maxRetries      int
 }
 
@@ -406,7 +406,7 @@ func newRequestPatchBuilder(src *types.RequestPatch, resourceVersion string, max
 		name:            src.Name,
 		keySpaceSize:    src.KeySpaceSize,
 		patchType:       patchType,
-		rawBody:         src.Body,
+		body:            src.Body,
 		maxRetries:      maxRetries,
 	}
 }
@@ -433,7 +433,7 @@ func (b *requestPatchBuilder) Build(cli rest.Interface) Requester {
 
 	// Render a unique body per request if patchRandomPlaceholder exists. Bodies without the
 	// placeholder pass through unchanged.
-	reqBody := renderPatchBody(b.rawBody)
+	reqBody := renderPatchBody(b.body)
 
 	return &DiscardRequester{
 		BaseRequester: BaseRequester{

--- a/request/random.go
+++ b/request/random.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -365,6 +366,13 @@ func (b *requestGetPodLogBuilder) Build(cli rest.Interface) Requester {
 	}
 }
 
+// patchRandomPlaceholder is a token that, when present in a patch body, is
+// replaced on every request with a random string. This guarantees each patch
+// actually mutates the target object instead of re-applying identical data
+// (which the apiserver treats as a no-op that bumps no resourceVersion and
+// emits no watch event).
+const patchRandomPlaceholder = "{{.Random}}"
+
 type requestPatchBuilder struct {
 	version         schema.GroupVersion
 	resource        string
@@ -373,8 +381,33 @@ type requestPatchBuilder struct {
 	name            string
 	keySpaceSize    int
 	patchType       apitypes.PatchType
-	body            interface{}
+	rawBody         string
 	maxRetries      int
+}
+
+// renderPatchBody replaces every occurrence of patchRandomPlaceholder in raw
+// with a random string. A body without the placeholder is returned unchanged
+// (backward compatible with existing profiles).
+func renderPatchBody(raw string) []byte {
+	if !strings.Contains(raw, patchRandomPlaceholder) {
+		return []byte(raw)
+	}
+	return []byte(strings.ReplaceAll(raw, patchRandomPlaceholder, randomString(8)))
+}
+
+// randomString returns a random lowercase string of length n, suitable for
+// making each rendered patch body unique.
+func randomString(n int) string {
+	const letters = "abcdefghijklmnopqrstuvwxyz"
+	b := make([]byte, n)
+	for i := range b {
+		idx, err := rand.Int(rand.Reader, big.NewInt(int64(len(letters))))
+		if err != nil {
+			panic(err)
+		}
+		b[i] = letters[idx.Int64()]
+	}
+	return string(b)
 }
 
 func newRequestPatchBuilder(src *types.RequestPatch, resourceVersion string, maxRetries int) *requestPatchBuilder {
@@ -391,7 +424,7 @@ func newRequestPatchBuilder(src *types.RequestPatch, resourceVersion string, max
 		name:            src.Name,
 		keySpaceSize:    src.KeySpaceSize,
 		patchType:       patchType,
-		body:            []byte(src.Body),
+		rawBody:         src.Body,
 		maxRetries:      maxRetries,
 	}
 }
@@ -416,11 +449,15 @@ func (b *requestPatchBuilder) Build(cli rest.Interface) Requester {
 	finalName := fmt.Sprintf("%s-%d", b.name, suffix)
 	comps = append(comps, b.resource, finalName)
 
+	// Render a unique body per request if patchRandomPlaceholder exists. Bodies without the
+	// placeholder pass through unchanged.
+	reqBody := renderPatchBody(b.rawBody)
+
 	return &DiscardRequester{
 		BaseRequester: BaseRequester{
 			method: "PATCH",
 			req: cli.Patch(b.patchType).AbsPath(comps...).
-				Body(b.body).
+				Body(reqBody).
 				MaxRetries(b.maxRetries),
 		},
 	}

--- a/request/random.go
+++ b/request/random.go
@@ -389,22 +389,7 @@ func renderPatchBody(raw string) []byte {
 	if !strings.Contains(raw, patchRandomPlaceholder) {
 		return []byte(raw)
 	}
-	return []byte(strings.ReplaceAll(raw, patchRandomPlaceholder, randomString(8)))
-}
-
-// randomString returns a random lowercase string of length n, suitable for
-// making each rendered patch body unique.
-func randomString(n int) string {
-	const letters = "abcdefghijklmnopqrstuvwxyz"
-	b := make([]byte, n)
-	for i := range b {
-		idx, err := rand.Int(rand.Reader, big.NewInt(int64(len(letters))))
-		if err != nil {
-			panic(err)
-		}
-		b[i] = letters[idx.Int64()]
-	}
-	return string(b)
+	return []byte(strings.ReplaceAll(raw, patchRandomPlaceholder, randomPayload(8)))
 }
 
 func newRequestPatchBuilder(src *types.RequestPatch, resourceVersion string, maxRetries int) *requestPatchBuilder {

--- a/request/random_test.go
+++ b/request/random_test.go
@@ -33,15 +33,18 @@ func TestRenderPatchBody(t *testing.T) {
 	assert.Equal(t, static, string(renderPatchBody(static)))
 }
 
-func TestRandomString(t *testing.T) {
+func TestRandomPayload(t *testing.T) {
 	const n = 8
-	s := randomString(n)
+	s := randomPayload(n)
 	assert.Len(t, s, n)
 	for _, r := range s {
-		assert.True(t, r >= 'a' && r <= 'z', "unexpected char %q", r)
+		isAlnum := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
+		assert.True(t, isAlnum, "unexpected char %q", r)
 	}
+	// n <= 0 returns an empty string.
+	assert.Equal(t, "", randomPayload(0))
 	// Two calls should not collide.
-	assert.NotEqual(t, randomString(n), randomString(n))
+	assert.NotEqual(t, randomPayload(n), randomPayload(n))
 }
 
 func TestRequestPatchBuilderRendersUniqueBodies(t *testing.T) {

--- a/request/random_test.go
+++ b/request/random_test.go
@@ -61,8 +61,8 @@ func TestRequestPatchBuilderRendersUniqueBodies(t *testing.T) {
 	}, "", 0)
 
 	// Each call renders a fresh random body, producing a distinct result.
-	first := string(renderPatchBody(b.rawBody))
-	second := string(renderPatchBody(b.rawBody))
+	first := string(renderPatchBody(b.body))
+	second := string(renderPatchBody(b.body))
 	assert.NotEqual(t, first, second)
 	assert.NotContains(t, first, patchRandomPlaceholder)
 	assert.NotContains(t, second, patchRandomPlaceholder)
@@ -91,7 +91,7 @@ func TestRequestPatchBuilderRendersConcurrencySafe(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < perGoroutine; j++ {
-				body := string(renderPatchBody(b.rawBody))
+				body := string(renderPatchBody(b.body))
 				assert.NotContains(t, body, patchRandomPlaceholder)
 				mu.Lock()
 				seen[body] = struct{}{}

--- a/request/random_test.go
+++ b/request/random_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package request
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/Azure/kperf/api/types"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderPatchBody(t *testing.T) {
+	const tmpl = `{"metadata":{"labels":{"bench-tick":"{{.Random}}"}}}`
+
+	// Placeholder is replaced with a random string, so the result no longer
+	// contains the placeholder and differs from the raw template.
+	rendered := string(renderPatchBody(tmpl))
+	assert.NotContains(t, rendered, patchRandomPlaceholder)
+	assert.NotEqual(t, tmpl, rendered)
+
+	// Each render produces a distinct body.
+	assert.NotEqual(t, string(renderPatchBody(tmpl)), string(renderPatchBody(tmpl)))
+
+	// Every occurrence is replaced.
+	multi := string(renderPatchBody(`{"a":"{{.Random}}","b":"{{.Random}}"}`))
+	assert.NotContains(t, multi, patchRandomPlaceholder)
+
+	// A body without the placeholder is returned unchanged (backward compatible).
+	const static = `{"metadata":{"labels":{"bench-tick":"1"}}}`
+	assert.Equal(t, static, string(renderPatchBody(static)))
+}
+
+func TestRandomString(t *testing.T) {
+	const n = 8
+	s := randomString(n)
+	assert.Len(t, s, n)
+	for _, r := range s {
+		assert.True(t, r >= 'a' && r <= 'z', "unexpected char %q", r)
+	}
+	// Two calls should not collide.
+	assert.NotEqual(t, randomString(n), randomString(n))
+}
+
+func TestRequestPatchBuilderRendersUniqueBodies(t *testing.T) {
+	b := newRequestPatchBuilder(&types.RequestPatch{
+		KubeGroupVersionResource: types.KubeGroupVersionResource{
+			Version:  "v1",
+			Resource: "configmaps",
+		},
+		Namespace:    "bench",
+		Name:         "cm",
+		KeySpaceSize: 100,
+		PatchType:    "merge",
+		Body:         `{"metadata":{"labels":{"bench-tick":"{{.Random}}"}}}`,
+	}, "", 0)
+
+	// Each call renders a fresh random body, producing a distinct result.
+	first := string(renderPatchBody(b.rawBody))
+	second := string(renderPatchBody(b.rawBody))
+	assert.NotEqual(t, first, second)
+	assert.NotContains(t, first, patchRandomPlaceholder)
+	assert.NotContains(t, second, patchRandomPlaceholder)
+}
+
+func TestRequestPatchBuilderRendersConcurrencySafe(t *testing.T) {
+	b := newRequestPatchBuilder(&types.RequestPatch{
+		KubeGroupVersionResource: types.KubeGroupVersionResource{
+			Version:  "v1",
+			Resource: "configmaps",
+		},
+		Name:      "cm",
+		PatchType: "merge",
+		Body:      `{"n":"{{.Random}}"}`,
+	}, "", 0)
+
+	const goroutines = 16
+	const perGoroutine = 100
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	seen := make(map[string]struct{}, goroutines*perGoroutine)
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perGoroutine; j++ {
+				body := string(renderPatchBody(b.rawBody))
+				assert.NotContains(t, body, patchRandomPlaceholder)
+				mu.Lock()
+				seen[body] = struct{}{}
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Random bodies are effectively unique across all requests.
+	assert.Equal(t, goroutines*perGoroutine, len(seen))
+}


### PR DESCRIPTION
## Summary
- Specify a placeholder which allows a random string to be injected for Patch request body.
- Update the `RequestPatch.Body` doc comment in `api/types/load_traffic.go` accordingly.

## Behavior
- The literal token `{{.Random}}` in a patch `body` is replaced on every request with a fresh random string, guaranteeing each patch is a real mutation (bumps resourceVersion, emits watch events) rather than a no-op.
- A body without the token is sent unchanged (backward compatible).

## Test plan
- [x] `go build ./...`
- [x] `go test ./request/` — updated tests assert the placeholder is replaced, bodies differ across renders, and rendering is concurrency-safe (16×100 distinct bodies)